### PR TITLE
Correction du rendu de la carte des passages

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -29,7 +29,8 @@
         {% endfor %}
       </tbody>
     </table>
-    <h2>Carte des zones</h2>
+    <h2>Carte des passages</h2>
+    <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
     <div>
       {{ map_html|safe }}
     </div>

--- a/zone.py
+++ b/zone.py
@@ -129,20 +129,24 @@ def aggregate_overlapping_zones(daily_zones):
     return final
 
 
-def generate_map(zones, raw_points=None, output="static/carte.html"):
-    """Créer une carte Folium avec zones et points GPS."""
+def _build_map(zones, raw_points=None):
+    """Construit un objet ``folium.Map`` pour les zones fournies."""
     if not zones:
-        print("Aucune zone à afficher.")
-        return
+        return None
     polys = []
     for z in zones:
-        g = z['geometry']
+        g = z["geometry"]
         if isinstance(g, Polygon):
             polys.append(g)
-        else:
-            polys.extend(list(g.geoms))
-    multi = MultiPolygon(polys)
-    ctr = shp_transform(_transformer, multi.centroid)
+        elif isinstance(g, MultiPolygon):
+            polys.extend([p for p in g.geoms])
+        elif isinstance(g, GeometryCollection):
+            polys.extend([geom for geom in g.geoms if isinstance(geom, Polygon)])
+    if not polys:
+        return None
+    from shapely.ops import unary_union
+    union = unary_union(polys)
+    ctr = shp_transform(_transformer, union.centroid)
     m = folium.Map(location=[ctr.y, ctr.x], zoom_start=12)
     if raw_points:
         for pt in raw_points:
@@ -165,7 +169,28 @@ def generate_map(zones, raw_points=None, output="static/carte.html"):
             popup=popup,
             tooltip=f"{count} passage(s)"
         ).add_to(m)
-    m.save(output)
+    return m
+
+
+def generate_map_html(zones, raw_points=None):
+    """Retourne le code HTML d'une carte Folium pour les zones."""
+    m = _build_map(zones, raw_points)
+    if m is None:
+        return None
+    # ``Map.get_root().render()`` renvoie une page HTML complète, ce qui
+    # n'est pas adapté à l'inclusion dans un gabarit existant. ``_repr_html_``
+    # renvoie uniquement le fragment à insérer.
+    return m._repr_html_()
+
+
+def generate_map(zones, raw_points=None, output="static/carte.html"):
+    """Créer un fichier HTML contenant la carte des zones."""
+    html = generate_map_html(zones, raw_points)
+    if html is None:
+        print("Aucune zone à afficher.")
+        return
+    with open(output, "w", encoding="utf-8") as fh:
+        fh.write(html)
 
 
 


### PR DESCRIPTION
## Summary
- utilise `_repr_html_` pour renvoyer un fragment HTML compatible avec le gabarit

## Testing
- `python -m py_compile app.py models.py zone.py`


------
https://chatgpt.com/codex/tasks/task_e_688672ca1910832282fdae3048fc05ad