### PR TITLE
Fix analyser_equipement call

### DIFF
--- a/zone.py
+++ b/zone.py
@@ -388,4 +388,4 @@ def analyse_quotidienne():
 
 def analyser_equipement(eq, start_date=None):
     """Alias pour compatibilité: analyse d'un équipement donné depuis start_date."""
-    process_equipment(eq, BASE_URL, db, since=start_date, date_ref=start_date)
+    process_equipment(eq, BASE_URL, db, since=start_date)


### PR DESCRIPTION
## Summary
- remove obsolete `date_ref` argument from `analyser_equipement`

## Testing
- `python -m py_compile zone.py app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68876fb293848322bf883eb0553bb7a5