### PR TITLE
Add dates to map popups

### DIFF
--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -141,6 +141,7 @@ def test_build_map_and_generate(tmp_path):
     assert fmap is not None
     html = zone.generate_map_html(zones)
     assert "folium-map" in html
+    assert "2023-01-01" in html
 
     out = tmp_path / "map.html"
     zone.generate_map(zones, output=str(out))

--- a/zone.py
+++ b/zone.py
@@ -158,10 +158,13 @@ def _build_map(zones, raw_points=None):
             geoms = [g for g in geom.geoms if isinstance(g, Polygon)]
             geom = MultiPolygon(geoms)
         count = len(z['dates'])
-        popup = folium.Popup(
-            f"<b>Passages:</b> {count}<br><b>Surface:</b> {(z['geometry'].area/1e4):.2f} ha",
-            max_width=250
-        )
+        dates_list = ", ".join(sorted(z['dates']))
+        popup_text = (
+            f"<b>Passages:</b> {count}<br>"
+            f"<b>Surface:</b> {(z['geometry'].area/1e4):.2f} ha")
+        if dates_list:
+            popup_text += f"<br><b>Dates:</b> {dates_list}"
+        popup = folium.Popup(popup_text, max_width=250)
         idx = min(count - 1, len(colors) - 1)
         folium.GeoJson(
             geom,


### PR DESCRIPTION
## Summary
- show visit dates in popup when rendering zones
- test map snippet includes dates

## Testing
- `flake8 .` *(fails: E501 and other existing style issues)*
- `mypy .`
- `pytest --cov=. -q`

------
https://chatgpt.com/codex/tasks/task_e_688833656b5483229ab75b3e5b380932