### PR TITLE
Ajout page de gestion utilisateurs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Ce fichier `Agents.md` fournit des directives claires pour OpenAI Codex et autre
 - Ajouter les nouvelles routes dans `app.py` (ou via Blueprint futur)
 - Réutiliser les layouts Bootstrap existants dans les templates HTML
 - L'initialisation de la base s'effectue via `@app.before_first_request`
+- Restreindre les routes d'administration (`/admin`, `/users`, `/initdb`)
+  aux comptes disposant d'un rôle **admin**
 
 ### Traitement de données GPS
 

--- a/app.py
+++ b/app.py
@@ -29,7 +29,11 @@ def create_app():
         return User.query.get(int(user_id))
 
     @app.route('/initdb')
+    @login_required
     def initdb():
+        if not current_user.is_admin:
+            return redirect(url_for('index'))
+
         db.create_all()
         # Création de l'utilisateur admin initial
         admin_user = os.environ.get('APP_USERNAME')
@@ -101,6 +105,49 @@ def create_app():
             existing_token=existing_token,
             message=message
         )
+
+    @app.route('/users', methods=['GET', 'POST'])
+    @login_required
+    def users():
+        if not current_user.is_admin:
+            return redirect(url_for('index'))
+
+        message = None
+        if request.method == 'POST':
+            action = request.form.get('action')
+            if action == 'add':
+                username = request.form.get('username')
+                password = request.form.get('password')
+                role = request.form.get('role')
+                if username and password:
+                    if User.query.filter_by(username=username).first():
+                        message = "Utilisateur déjà existant"
+                    else:
+                        user = User(
+                            username=username, is_admin=(role == 'admin')
+                        )
+                        user.set_password(password)
+                        db.session.add(user)
+                        db.session.commit()
+                        message = "Utilisateur ajouté"
+            elif action == 'reset':
+                uid = request.form.get('user_id')
+                password = request.form.get('password')
+                user = User.query.get(int(uid)) if uid else None
+                if user and password:
+                    user.set_password(password)
+                    db.session.commit()
+                    message = "Mot de passe réinitialisé"
+            elif action == 'delete':
+                uid = request.form.get('user_id')
+                user = User.query.get(int(uid)) if uid else None
+                if user and user != current_user:
+                    db.session.delete(user)
+                    db.session.commit()
+                    message = "Utilisateur supprimé"
+
+        users = User.query.all()
+        return render_template('users.html', users=users, message=message)
 
     @app.route('/', methods=['GET', 'POST'])
     @login_required

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,8 +12,8 @@
       <h1>Résumé des équipements</h1>
       <div>
         {% if current_user.is_admin %}
-        <a href="{{ url_for('admin') }}" 
-           class="btn btn-sm btn-secondary">Admin</a>
+        <a href="{{ url_for('admin') }}" class="btn btn-sm btn-secondary">Admin</a>
+        <a href="{{ url_for('users') }}" class="btn btn-sm btn-secondary ms-2">Utilisateurs</a>
         {% endif %}
         <a href="{{ url_for('logout') }}" 
            class="btn btn-sm btn-outline-secondary">Déconnexion</a>

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Gestion des utilisateurs</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="p-4">
+  <div class="container">
+    <div class="d-flex justify-content-between mb-3">
+      <h1 class="h3">Utilisateurs</h1>
+      <div>
+        <a href="{{ url_for('index') }}" class="btn btn-sm btn-outline-secondary">Retour</a>
+        <a href="{{ url_for('logout') }}" class="btn btn-sm btn-outline-secondary">Déconnexion</a>
+      </div>
+    </div>
+
+    {% if message %}
+    <div class="alert alert-info">{{ message }}</div>
+    {% endif %}
+
+    <h5 class="mt-4">Ajouter un utilisateur</h5>
+    <form method="post" class="row g-2 mb-4">
+      <input type="hidden" name="action" value="add">
+      <div class="col-auto">
+        <input type="text" name="username" class="form-control" placeholder="Nom d'utilisateur" required>
+      </div>
+      <div class="col-auto">
+        <input type="password" name="password" class="form-control" placeholder="Mot de passe" required>
+      </div>
+      <div class="col-auto">
+        <select name="role" class="form-select">
+          <option value="read">Lecture</option>
+          <option value="admin">Admin</option>
+        </select>
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Ajouter</button>
+      </div>
+    </form>
+
+    <h5 class="mt-4">Utilisateurs existants</h5>
+    <table class="table table-bordered align-middle">
+      <thead class="table-light">
+        <tr>
+          <th>Nom</th>
+          <th>Rôle</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user in users %}
+        <tr>
+          <td>{{ user.username }}</td>
+          <td>{{ 'Admin' if user.is_admin else 'Lecture' }}</td>
+          <td>
+            <form method="post" class="d-inline">
+              <input type="hidden" name="action" value="reset">
+              <input type="hidden" name="user_id" value="{{ user.id }}">
+              <input type="password" name="password" class="form-control d-inline w-auto" placeholder="Nouveau mot de passe" required>
+              <button type="submit" class="btn btn-sm btn-warning ms-1">Réinitialiser</button>
+            </form>
+            {% if user != current_user %}
+            <form method="post" class="d-inline ms-2">
+              <input type="hidden" name="action" value="delete">
+              <input type="hidden" name="user_id" value="{{ user.id }}">
+              <button type="submit" class="btn btn-sm btn-danger">Supprimer</button>
+            </form>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,111 @@
+import os
+import sys
+import pytest
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
+os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
+
+from app import create_app
+from models import db, User
+
+
+def make_app():
+    app = create_app()
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", is_admin=True)
+        admin.set_password("pass")
+        db.session.add(admin)
+        db.session.commit()
+    return app
+
+
+def login(client, username="admin", password="pass"):
+    return client.post("/login", data={"username": username, "password": password})
+
+
+def test_non_admin_cannot_access_users():
+    app = make_app()
+    with app.app_context():
+        u = User(username="reader", is_admin=False)
+        u.set_password("pwd")
+        db.session.add(u)
+        db.session.commit()
+    client = app.test_client()
+    login(client, "reader", "pwd")
+    resp = client.get("/users")
+    assert resp.status_code == 302
+
+
+def test_non_admin_cannot_access_admin_page():
+    app = make_app()
+    with app.app_context():
+        u = User(username="reader", is_admin=False)
+        u.set_password("pwd")
+        db.session.add(u)
+        db.session.commit()
+    client = app.test_client()
+    login(client, "reader", "pwd")
+    resp = client.get("/admin")
+    assert resp.status_code == 302
+
+
+def test_non_admin_cannot_access_initdb():
+    app = make_app()
+    with app.app_context():
+        u = User(username="reader", is_admin=False)
+        u.set_password("pwd")
+        db.session.add(u)
+        db.session.commit()
+    client = app.test_client()
+    login(client, "reader", "pwd")
+    resp = client.get("/initdb")
+    assert resp.status_code == 302
+
+
+def test_admin_add_and_delete_user():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    resp = client.post(
+        "/users",
+        data={
+            "action": "add",
+            "username": "bob",
+            "password": "secret",
+            "role": "read",
+        },
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(username="bob").first()
+        assert user is not None
+        uid = user.id
+    client.post("/users", data={"action": "delete", "user_id": str(uid)})
+    with app.app_context():
+        assert User.query.filter_by(username="bob").first() is None
+
+
+def test_password_reset():
+    app = make_app()
+    with app.app_context():
+        u = User(username="temp", is_admin=False)
+        u.set_password("old")
+        db.session.add(u)
+        db.session.commit()
+        uid = u.id
+    client = app.test_client()
+    login(client)
+    client.post(
+        "/users",
+        data={"action": "reset", "user_id": str(uid), "password": "new"},
+    )
+    with app.app_context():
+        user = User.query.get(uid)
+        assert user.check_password("new")


### PR DESCRIPTION
## Summary
- ajouter une route `/users` dans `app.py`
- créer le template `users.html` pour gérer les comptes
- lister et ajouter un lien "Utilisateurs" depuis la page d'accueil
- tests unitaires pour la gestion des utilisateurs
- restreindre les routes administratives aux comptes admin
- update AGENTS documentation

## Testing
- `flake8 .` *(fails: E501 etc.)*
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888364eb39483228466851a9f8f9405