### PR TITLE
Improve equipment page layout

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -4,6 +4,12 @@
   <meta charset="utf-8">
   <title>{{ equipment.name }} - Détails</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <style>
+    /* Ensure Folium maps scale properly within the Bootstrap grid */
+    .folium-map {
+      width: 100%;
+    }
+  </style>
 </head>
 <body class="p-4">
   <div class="container">
@@ -14,25 +20,31 @@
         <a href="{{ url_for('logout') }}" class="btn btn-sm btn-outline-secondary">Déconnexion</a>
       </div>
     </div>
-    <h2>Zones journalières</h2>
     {% if zones %}
-    <table class="table table-striped">
-      <thead>
-        <tr><th>Date</th><th>Surface (ha)</th></tr>
-      </thead>
-      <tbody>
-        {% for z in zones %}
-        <tr>
-          <td>{{ z.date }}</td>
-          <td>{{ z.surface_ha|round(2) }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <h2>Carte des passages</h2>
-    <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
-    <div>
-      {{ map_html|safe }}
+    <div class="row">
+      <div class="col-md-6 mb-4">
+        <h2>Zones journalières</h2>
+        <table class="table table-striped">
+          <thead>
+            <tr><th>Date</th><th>Surface (ha)</th></tr>
+          </thead>
+          <tbody>
+            {% for z in zones %}
+            <tr>
+              <td>{{ z.date }}</td>
+              <td>{{ z.surface_ha|round(2) }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="col-md-6">
+        <h2>Carte des passages</h2>
+        <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
+        <div>
+          {{ map_html|safe }}
+        </div>
+      </div>
     </div>
     {% else %}
     <p>Aucune donnée disponible pour cet équipement.</p>


### PR DESCRIPTION
## Summary
- show the zone table and the map side by side on large screens

## Testing
- `python -m py_compile app.py models.py zone.py`


------
https://chatgpt.com/codex/tasks/task_e_68883adb99e0832281b0697fe8ed47b1