### PR TITLE
Improve equipment page layout

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -18,24 +18,31 @@
     {% if zones %}
     <style>
       .zone-row { cursor: pointer; }
+      #map-container { height: 70vh; }
     </style>
-    <table id="zones-table" class="table table-striped">
-      <thead>
-        <tr><th>Date</th><th>Surface (ha)</th></tr>
-      </thead>
-      <tbody>
-        {% for z in zones %}
-        <tr class="zone-row" data-date="{{ z.date }}">
-          <td>{{ z.date }}</td>
-          <td>{{ z.surface_ha|round(2) }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <h2>Carte des passages</h2>
-    <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
-    <div id="map-container">
-      {{ map_html|safe }}
+    <div class="row">
+      <div class="col-md-4 mb-4">
+        <table id="zones-table" class="table table-striped">
+          <thead>
+            <tr><th>Date</th><th>Surface (ha)</th></tr>
+          </thead>
+          <tbody>
+            {% for z in zones %}
+            <tr class="zone-row" data-date="{{ z.date }}">
+              <td>{{ z.date }}</td>
+              <td>{{ z.surface_ha|round(2) }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="col-md-8">
+        <h2>Carte des passages</h2>
+        <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
+        <div id="map-container">
+          {{ map_html|safe }}
+        </div>
+      </div>
     </div>
     {% else %}
     <p>Aucune donnée disponible pour cet équipement.</p>

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from datetime import date
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
+os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
+
+from app import create_app  # noqa: E402
+from models import db, User, Equipment, DailyZone  # noqa: E402
+
+
+def make_app():
+    app = create_app()
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", is_admin=True)
+        admin.set_password("pass")
+        db.session.add(admin)
+        eq = Equipment(id_traccar=1, name="tractor")
+        db.session.add(eq)
+        db.session.commit()
+
+        dz = DailyZone(
+            equipment_id=eq.id,
+            date=date.today(),
+            surface_ha=1.0,
+            polygon_wkt="POLYGON((0 0,1 0,1 1,0 1,0 0))",
+        )
+        db.session.add(dz)
+        db.session.commit()
+    return app
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "admin", "password": "pass"},
+    )
+
+
+def test_equipment_detail_page_loads(monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    # Simplifier la génération de carte
+    monkeypatch.setattr("zone.generate_map_html", lambda *_: "<div>map</div>")
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    assert resp.status_code == 200
+    assert b"map" in resp.data


### PR DESCRIPTION
## Summary
- show daily zones table and map side-by-side for better overview
- add integration test for equipment detail page

## Testing
- `flake8 . | head`
- `mypy . | head`
- `pytest --cov=. | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68883c2d95ac8322b2aa98fab65d0d7b