### PR TITLE
Automatise l'analyse au démarrage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Les agents peuvent être exécutés automatiquement ou manuellement :
 | Agent                      | Fréquence        | Déclenchement |
 |----------------------------|------------------|----------------|
 | `analyseur_zones_journalières` | chaque nuit      | APScheduler    |
-| `analyse_manuelle`         | à la demande     | UI utilisateur |
+| `analyse_initiale`         | au démarrage     | automatique |
 | `rapport_par_tracteur`     | futur            | script manuel  |
 | `verificateur_inactivite`  | futur            | planifié       |
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -51,6 +51,10 @@
 
       <button type="submit" class="btn btn-primary">Enregistrer la configuration</button>
     </form>
+
+    <form method="post" action="{{ url_for('reanalyze_all') }}" class="mt-3">
+      <button type="submit" class="btn btn-danger">Tout réanalyser</button>
+    </form>
   </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,6 @@
           <th>Ha uniques</th>
           <th>Distance zones (km)</th>
           <th>Temps écoulé</th>
-          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -49,14 +48,6 @@
           <td>{{ eq.relative_hectares|round(2) }}</td>
           <td>{{ eq.distance_km|round(2) }}</td>
           <td>{{ eq.delta_str }}</td>
-          <td>
-            <form method="post" class="d-inline">
-              <input type="hidden" name="equip_id" value="{{ eq.id }}">
-              <button type="submit" class="btn btn-sm btn-primary">
-                Analyser
-              </button>
-            </form>
-          </td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- trigger global re-analysis from admin page
- remove manual analysis button on index
- analyze all equipment at startup if tables exist
- document new `analyse_initiale` agent
- test re-analysis permission rules

## Testing
- `flake8 .`
- `python -m mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68883c403dc08322bd25d8acbce5582d