### PR TITLE
Implement setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Trackteur Analyse interroge l'API Traccar, agrège les positions par jour et cal
 2. [Prérequis](#prérequis)
 3. [Installation](#installation)
 4. [Configuration](#configuration)
-5. [Initialisation de la base](#initialisation-de-la-base)
-6. [Utilisation](#utilisation)
-7. [Structure du projet](#structure-du-projet)
-8. [Contribution](#contribution)
-9. [Licence](#licence)
+5. [Utilisation](#utilisation)
+6. [Structure du projet](#structure-du-projet)
+7. [Contribution](#contribution)
+8. [Licence](#licence)
 
 ## Fonctionnalités
 - Authentification avec gestion d'un utilisateur administrateur
@@ -35,31 +34,13 @@ pip install -r requirements.txt
 ```
 
 ## Configuration
-Avant le lancement, définissez les variables d'environnement suivantes (ou placez-les dans un fichier `.env`) :
+Au premier lancement, ouvrez l'application dans votre navigateur. Un assistant se lance automatiquement pour :
+1. Créer le compte administrateur
+2. Saisir l'URL et le token du serveur Traccar
+3. Choisir les appareils à suivre
+4. Lancer une analyse initiale
 
-| Variable | Description |
-|----------|-------------|
-| `TRACCAR_AUTH_TOKEN` | Token d'authentification pour l'API Traccar |
-| `TRACCAR_BASE_URL` | URL de base de votre serveur (ex. `https://mon.traccar/api`) |
-| `APP_USERNAME` | Identifiant de connexion |
-| `APP_PASSWORD` | Mot de passe associé |
-| `FLASK_SECRET_KEY` | *(optionnel)* Clé secrète Flask |
-
-Exemple :
-```bash
-export TRACCAR_AUTH_TOKEN="votre_token"
-export TRACCAR_BASE_URL="https://mon.traccar/api"
-export APP_USERNAME="admin"
-export APP_PASSWORD="motdepasse"
-```
-
-## Initialisation de la base
-
-Lors du premier démarrage :
-```bash
-python app.py
-```
-Puis ouvrez [http://localhost:5000/initdb](http://localhost:5000/initdb) pour créer la base. Si `APP_USERNAME` et `APP_PASSWORD` sont définies, un compte administrateur est généré.
+Seule la variable `FLASK_SECRET_KEY` peut être définie au besoin.
 
 ## Utilisation
 

--- a/app.py
+++ b/app.py
@@ -30,6 +30,19 @@ def create_app():
     login_manager = LoginManager(app)
     login_manager.login_view = 'login'
 
+    if hasattr(app, "before_first_request"):
+        @app.before_first_request
+        def init_db() -> None:
+            """Crée les tables de la base si nécessaire."""
+            db.create_all()
+    else:
+        @app.before_request
+        def init_db_once() -> None:
+            """Fallback pour Flask 3 sans before_first_request."""
+            if not getattr(app, "_db_init", False):
+                db.create_all()
+                app._db_init = True
+
     @app.before_request
     def ensure_setup():
         allowed = {'setup', 'static'}

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from flask_login import (
 )
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from models import db, User, Equipment, DailyZone
+from models import db, User, Equipment, DailyZone, Config
 import zone
 
 from datetime import datetime
@@ -30,27 +30,23 @@ def create_app():
     login_manager = LoginManager(app)
     login_manager.login_view = 'login'
 
+    @app.before_request
+    def ensure_setup():
+        allowed = {'setup', 'static'}
+        if request.endpoint in allowed:
+            return
+        if User.query.count() == 0:
+            return redirect(url_for('setup'))
+        if Config.query.count() == 0:
+            if current_user.is_authenticated or request.endpoint != 'login':
+                return redirect(url_for('setup'))
+        if Equipment.query.count() == 0:
+            if current_user.is_authenticated or request.endpoint != 'login':
+                return redirect(url_for('setup'))
+
     @login_manager.user_loader
     def load_user(user_id):
         return User.query.get(int(user_id))
-
-    @app.route('/initdb')
-    @login_required
-    def initdb():
-        if not current_user.is_admin:
-            return redirect(url_for('index'))
-
-        db.create_all()
-        # Création de l'utilisateur admin initial
-        admin_user = os.environ.get('APP_USERNAME')
-        admin_pass = os.environ.get('APP_PASSWORD')
-        if admin_user and admin_pass:
-            if not User.query.filter_by(username=admin_user).first():
-                u = User(username=admin_user, is_admin=True)
-                u.set_password(admin_pass)
-                db.session.add(u)
-                db.session.commit()
-        return 'Base de données initialisée.'
 
     @app.route('/login', methods=['GET', 'POST'])
     def login():
@@ -70,6 +66,68 @@ def create_app():
     def logout():
         logout_user()
         return redirect(url_for('login'))
+
+    @app.route('/setup', methods=['GET', 'POST'])
+    def setup():
+        """Assistant de première configuration."""
+        # Détermination de l'étape
+        if User.query.count() == 0:
+            step = 1
+        elif Config.query.count() == 0:
+            step = 2
+        elif Equipment.query.count() == 0:
+            step = 3
+        else:
+            step = 4
+
+        if step == 1:
+            if request.method == 'POST':
+                username = request.form.get('username')
+                password = request.form.get('password')
+                if username and password:
+                    admin = User(username=username, is_admin=True)
+                    admin.set_password(password)
+                    db.session.add(admin)
+                    db.session.commit()
+                    return redirect(url_for('setup'))
+            return render_template('setup_step1.html')
+
+        if step == 2:
+            if request.method == 'POST':
+                url = request.form.get('base_url')
+                token = request.form.get('token')
+                if url and token:
+                    cfg = Config(traccar_url=url, traccar_token=token)
+                    db.session.add(cfg)
+                    db.session.commit()
+                    return redirect(url_for('setup'))
+            return render_template('setup_step2.html')
+
+        if step == 3:
+            devices = zone.fetch_devices()
+            if request.method == 'POST':
+                ids = {int(x) for x in request.form.getlist('equip_ids')}
+                cfg = Config.query.first()
+                for dev in devices:
+                    if dev['id'] in ids:
+                        eq = Equipment(
+                            id_traccar=dev['id'],
+                            name=dev['name'],
+                            token_api=cfg.traccar_token,
+                        )
+                        db.session.add(eq)
+                db.session.commit()
+                return redirect(url_for('setup'))
+            return render_template('setup_step3.html', devices=devices)
+
+        # step 4
+        now = datetime.utcnow()
+        start_of_year = datetime(now.year, 1, 1)
+        processed = []
+        for eq in Equipment.query.all():
+            zone.process_equipment(eq, since=start_of_year)
+            processed.append(eq.name)
+        return render_template('setup_step4.html', devices=processed)
 
     @app.route('/admin', methods=['GET', 'POST'])
     @login_required
@@ -123,7 +181,7 @@ def create_app():
         now = datetime.utcnow()
         start_of_year = datetime(now.year, 1, 1)
         for eq in Equipment.query.all():
-            zone.process_equipment(eq, zone.BASE_URL, db, since=start_of_year)
+            zone.process_equipment(eq, since=start_of_year)
 
         return redirect(url_for('admin', msg="Analyse complète terminée"))
 
@@ -261,9 +319,7 @@ def create_app():
             now = datetime.utcnow()
             start_of_year = datetime(now.year, 1, 1)
             for eq in Equipment.query.all():
-                zone.process_equipment(
-                    eq, zone.BASE_URL, db, since=start_of_year
-                )
+                zone.process_equipment(eq, since=start_of_year)
 
     if not os.environ.get("SKIP_INITIAL_ANALYSIS"):
         initial_analysis()

--- a/models.py
+++ b/models.py
@@ -18,6 +18,14 @@ class User(UserMixin, db.Model):  # type: ignore[name-defined]
         return check_password_hash(self.password_hash, password)
 
 
+class Config(db.Model):  # type: ignore[name-defined]
+    """Paramètres de connexion Traccar."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    traccar_url = db.Column(db.String, nullable=False)
+    traccar_token = db.Column(db.String, nullable=False)
+
+
 class Equipment(db.Model):  # type: ignore[name-defined]
     id = db.Column(db.Integer, primary_key=True)
     id_traccar = db.Column(db.Integer, nullable=False)

--- a/templates/setup_step1.html
+++ b/templates/setup_step1.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Configuration – Admin</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Création de l'administrateur</h1>
+    <form method="post">
+      <div class="mb-3">
+        <label for="username" class="form-label">Nom d'utilisateur</label>
+        <input type="text" class="form-control" id="username" name="username" required autofocus>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Mot de passe</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn btn-primary">Suivant</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/setup_step2.html
+++ b/templates/setup_step2.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Configuration – Serveur</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Connexion au serveur Traccar</h1>
+    <form method="post">
+      <div class="mb-3">
+        <label for="base_url" class="form-label">Adresse du serveur</label>
+        <input type="text" class="form-control" id="base_url" name="base_url" required>
+      </div>
+      <div class="mb-3">
+        <label for="token" class="form-label">Token API</label>
+        <input type="text" class="form-control" id="token" name="token" required>
+      </div>
+      <button type="submit" class="btn btn-primary">Suivant</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/setup_step3.html
+++ b/templates/setup_step3.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Configuration – Équipements</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Sélection des appareils à suivre</h1>
+    <form method="post">
+      <div class="mb-3">
+        {% for dev in devices %}
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" name="equip_ids" id="d{{ dev.id }}" value="{{ dev.id }}">
+          <label class="form-check-label" for="d{{ dev.id }}">{{ dev.name }}</label>
+        </div>
+        {% endfor %}
+      </div>
+      <button type="submit" class="btn btn-primary">Lancer l'analyse</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/setup_step4.html
+++ b/templates/setup_step4.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Configuration terminée</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Analyse initiale terminée</h1>
+    <ul>
+      {% for name in devices %}
+      <li>{{ name }} analysé</li>
+      {% endfor %}
+    </ul>
+    <a href="{{ url_for('index') }}" class="btn btn-primary">Accéder à l'application</a>
+  </div>
+</body>
+</html>

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -10,7 +10,7 @@ os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
 os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
 
 from app import create_app  # noqa: E402
-from models import db, User, Equipment, DailyZone  # noqa: E402
+from models import db, User, Equipment, DailyZone, Config  # noqa: E402
 
 
 def make_app():
@@ -24,6 +24,12 @@ def make_app():
         admin = User(username="admin", is_admin=True)
         admin.set_password("pass")
         db.session.add(admin)
+        db.session.add(
+            Config(
+                traccar_url="http://example.com",
+                traccar_token="dummy",
+            )
+        )
         eq = Equipment(id_traccar=1, name="tractor")
         db.session.add(eq)
         db.session.commit()

--- a/tests/test_setup_init.py
+++ b/tests/test_setup_init.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
+os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
+
+from app import create_app  # noqa: E402
+from models import db, User  # noqa: E402
+
+
+def test_setup_without_db():
+    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
+    app = create_app()
+    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+    client = app.test_client()
+    resp = client.get("/setup")
+    assert resp.status_code == 200
+    with app.app_context():
+        # Query succeeds because tables were created automatically
+        assert User.query.count() == 0

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -243,7 +243,7 @@ def test_process_equipment(monkeypatch):
                 lambda z: z,
             )
 
-            zone.process_equipment(eq, "http://example.com", zone.db)
+            zone.process_equipment(eq)
 
             dz = zone.DailyZone.query.filter_by(equipment_id=eq.id).first()
             assert dz is not None
@@ -351,7 +351,7 @@ def test_analyse_quotidienne(monkeypatch):
 
             called = []
 
-            def fake_process(e, base, db):
+            def fake_process(e):
                 called.append(e.id_traccar)
             monkeypatch.setattr(zone, "process_equipment", fake_process)
 
@@ -362,7 +362,7 @@ def test_analyse_quotidienne(monkeypatch):
 def test_analyser_equipement(monkeypatch):
     called = {}
 
-    def fake_process(eq, base, db, since=None):
+    def fake_process(eq, since=None):
         called["id"] = eq.id_traccar
         called["since"] = since
     monkeypatch.setattr(zone, "process_equipment", fake_process)
@@ -411,6 +411,6 @@ def test_distance_between_zones_calculation(monkeypatch):
                 lambda z: z,
             )
 
-            zone.process_equipment(eq, "http://example.com", zone.db)
+            zone.process_equipment(eq)
 
             assert eq.distance_between_zones > 0


### PR DESCRIPTION
## Summary
- add Config model for Traccar credentials
- create a `/setup` first-run wizard and guard all routes with a setup check
- remove old `/initdb` route
- adjust `zone` to load credentials from database or env
- update tests for new behaviour
- document new configuration process

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6888aaaa40348322ab24583606a0521a