### PR TITLE
Add activity score ranking

### DIFF
--- a/app.py
+++ b/app.py
@@ -257,26 +257,73 @@ def create_app():
             if eq.last_position:
                 last = eq.last_position.strftime('%Y-%m-%d %H:%M:%S')
                 delta = now - eq.last_position
+                delta_seconds = delta.total_seconds()
                 hours = delta.seconds // 3600
                 minutes = (delta.seconds % 3600) // 60
                 delta_str = f"{delta.days} j {hours} h {minutes} min"
             else:
                 last = None
+                delta_seconds = None
                 delta_str = "–"
+
+            distance_km = (eq.distance_between_zones or 0) / 1000
+            rel_hectares = zone.calculate_relative_hectares(eq.id)
+            ratio_eff = eq.total_hectares / distance_km if distance_km else 0.0
 
             equipment_data.append({
                 "id": eq.id,
                 "name": eq.name,
                 "last_seen": last,
                 "total_hectares": round(eq.total_hectares or 0, 2),
-                "relative_hectares": round(
-                    zone.calculate_relative_hectares(eq.id), 2
-                ),
-                "distance_km": round(
-                    (eq.distance_between_zones or 0) / 1000, 2
-                ),
-                "delta_str": delta_str
+                "relative_hectares": round(rel_hectares, 2),
+                "distance_km": round(distance_km, 2),
+                "delta_seconds": delta_seconds,
+                "ratio_eff": ratio_eff,
+                "delta_str": delta_str,
             })
+
+        # Normalisation des critères
+        def normalize(values, value, invert=False):
+            clean = [v for v in values if v is not None]
+            if not clean or value is None:
+                return 0.0
+            vmin = min(clean)
+            vmax = max(clean)
+            if vmax == vmin:
+                return 1.0
+            if invert:
+                return (vmax - value) / (vmax - vmin)
+            return (value - vmin) / (vmax - vmin)
+
+        times = [
+            d["delta_seconds"]
+            for d in equipment_data
+            if d["delta_seconds"] is not None
+        ]
+        totals = [d["total_hectares"] for d in equipment_data]
+        uniques = [d["relative_hectares"] for d in equipment_data]
+        distances = [d["distance_km"] for d in equipment_data]
+        ratios = [d["ratio_eff"] for d in equipment_data]
+
+        for d in equipment_data:
+            n_time = normalize(times, d["delta_seconds"], invert=True)
+            n_total = normalize(totals, d["total_hectares"])
+            n_unique = normalize(uniques, d["relative_hectares"])
+            n_dist = normalize(distances, d["distance_km"])
+            n_ratio = normalize(ratios, d["ratio_eff"])
+            d["score"] = round(
+                0.3 * n_time
+                + 0.3 * n_total
+                + 0.2 * n_unique
+                + 0.1 * n_dist
+                + 0.1 * n_ratio,
+                3,
+            )
+
+        equipment_data.sort(key=lambda x: x["score"], reverse=True)
+
+        for idx, d in enumerate(equipment_data, start=1):
+            d["rank"] = idx
 
         return render_template(
             'index.html',

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
           <th>Ha uniques</th>
           <th>Distance zones (km)</th>
           <th>Temps écoulé</th>
+          <th>Score</th>
         </tr>
       </thead>
       <tbody>
@@ -48,6 +49,14 @@
           <td>{{ eq.relative_hectares|round(2) }}</td>
           <td>{{ eq.distance_km|round(2) }}</td>
           <td>{{ eq.delta_str }}</td>
+          <td>
+            {{ eq.score }}
+            {% if eq.rank == 1 %}
+            <span class="ms-1">🥇</span>
+            {% elif eq.rank == 2 %}
+            <span class="ms-1">🥈</span>
+            {% endif %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_activity_score.py
+++ b/tests/test_activity_score.py
@@ -1,0 +1,93 @@
+import os
+import sys
+from datetime import date, datetime, timedelta
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
+os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
+
+from app import create_app  # noqa: E402
+from models import db, User, Equipment, DailyZone, Config  # noqa: E402
+import zone  # noqa: E402
+
+
+def make_app():
+    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
+    app = create_app()
+    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", is_admin=True)
+        admin.set_password("pass")
+        db.session.add(admin)
+        db.session.add(
+            Config(
+                traccar_url="http://example.com",
+                traccar_token="dummy",
+            )
+        )
+        now = datetime.utcnow()
+        eq1 = Equipment(
+            id_traccar=1,
+            name="T1",
+            total_hectares=10.0,
+            distance_between_zones=1000.0,
+            last_position=now - timedelta(hours=1),
+        )
+        eq2 = Equipment(
+            id_traccar=2,
+            name="T2",
+            total_hectares=5.0,
+            distance_between_zones=2000.0,
+            last_position=now - timedelta(hours=10),
+        )
+        db.session.add_all([eq1, eq2])
+        db.session.commit()
+        db.session.add_all([
+            DailyZone(
+                equipment_id=eq1.id,
+                date=date.today(),
+                surface_ha=10.0,
+                polygon_wkt="POLYGON((0 0,1 0,1 1,0 1,0 0))",
+            ),
+            DailyZone(
+                equipment_id=eq2.id,
+                date=date.today(),
+                surface_ha=5.0,
+                polygon_wkt="POLYGON((0 0,1 0,1 1,0 1,0 0))",
+            ),
+        ])
+        db.session.commit()
+    return app
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "admin", "password": "pass"},
+    )
+
+
+def test_index_sorted_by_score(monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        ids = {e.name: e.id for e in Equipment.query.all()}
+
+    def fake_rel(equipment_id: int) -> float:
+        return 9.0 if equipment_id == ids["T1"] else 4.0
+
+    monkeypatch.setattr(zone, "calculate_relative_hectares", fake_rel)
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "🥇" in html
+    assert html.index("T1") < html.index("T2")


### PR DESCRIPTION
## Summary
- compute activity score for equipment in index route
- display sorted score table with medal for top two
- add regression test for score sorting

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68891482b37083229f54f9fea1e2d831