### PR TITLE
Clarify environment variable usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,11 @@ Les agents peuvent être exécutés automatiquement ou manuellement :
 
 ---
 
-## 🔐 Variables d’environnement (recommandées)
+## 🔐 Variables d’environnement (optionnelles)
 
-Toutes les informations sensibles doivent être passées par variables d’environnement :
+Les paramètres Traccar peuvent être saisis via l'interface d'administration et
+sont enregistrés en base de données. Les variables ci-dessous permettent de
+fournir ou de surcharger cette configuration lors du déploiement :
 
 | Variable              | Rôle                                |
 |-----------------------|--------------------------------------|

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Au premier lancement, ouvrez l'application dans votre navigateur. Un assistant s
 3. Choisir les appareils à suivre
 4. Lancer une analyse initiale
 
-Seule la variable `FLASK_SECRET_KEY` est requise. Pour éviter la longue analyse initiale à chaque démarrage, vous pouvez définir `SKIP_INITIAL_ANALYSIS=1`.
+Les paramètres saisis sont enregistrés dans la base de données et restent
+disponibles au redémarrage. Vous pouvez néanmoins les fournir via les variables
+`TRACCAR_AUTH_TOKEN` et `TRACCAR_BASE_URL` (et `TRACCAR_DEVICE_NAME` si besoin)
+pour surcharger la configuration.
+
+Seule la variable `FLASK_SECRET_KEY` est obligatoire. Pour éviter la longue
+analyse initiale à chaque démarrage, vous pouvez définir
+`SKIP_INITIAL_ANALYSIS=1`.
 
 ## Utilisation
 


### PR DESCRIPTION
## Summary
- document that Traccar credentials are persisted in the DB
- clarify env var use in AGENTS.md and README

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_688a6f4815188322ba8dcb5ba8ee25da