### PR TITLE
Fix zone popups and aggregation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,14 @@
 import os
 
-from flask import Flask, render_template, request, redirect, url_for
+from flask import (
+    Flask,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    jsonify,
+    abort,
+)
 from flask_login import (
     LoginManager,
     login_user,
@@ -10,8 +18,7 @@ from flask_login import (
 )
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from models import db, User, Equipment, Position, DailyZone, Config
-from shapely.geometry import Point
+from models import db, User, Equipment, DailyZone, Config
 import zone
 
 from datetime import datetime
@@ -358,37 +365,63 @@ def create_app():
             .order_by(DailyZone.date.desc())
             .all()
         )
-        # Génération de la carte Folium avec comptage des passages
-        map_html = None
+        center = [46.0, 2.0]
+        bounds = None
         if zones:
             from shapely import wkt
+            from shapely.ops import unary_union
 
-            daily = [
-                {
-                    "geometry": wkt.loads(z.polygon_wkt),
-                    "dates": [str(z.date)]
-                }
-                for z in zones
-            ]
-
-            aggregated = zone.aggregate_overlapping_zones(daily)
-
-            raw_points = [
-                Point(p.longitude, p.latitude)
-                for p in (
-                    Position.query
-                    .filter_by(equipment_id=equipment_id)
-                    .order_by(Position.timestamp.desc())
-                    .all()
-                )
-            ]
-
-            map_html = zone.generate_map_html(
-                aggregated, raw_points=raw_points
-            )
+            geoms = [wkt.loads(z.polygon_wkt) for z in zones]
+            union = unary_union(geoms)
+            ctr = zone.shp_transform(zone._transformer, union.centroid)
+            center = [ctr.y, ctr.x]
+            b = zone.shp_transform(zone._transformer, union).bounds
+            bounds = [b[1], b[0], b[3], b[2]]
         return render_template(
-            'equipment.html', equipment=eq, zones=zones, map_html=map_html
+            'equipment.html',
+            equipment=eq,
+            zones=zones,
+            center=center,
+            bounds=bounds,
         )
+
+    @app.route('/equipment/<int:equipment_id>/zones.geojson')
+    @login_required
+    def equipment_zones_geojson(equipment_id):
+        Equipment.query.get_or_404(equipment_id)
+        bbox_param = request.args.get('bbox')
+        zoom = int(request.args.get('zoom', '12'))
+        bbox = None
+        if bbox_param:
+            parts = [p.strip() for p in bbox_param.split(',')]
+            if len(parts) != 4:
+                abort(400)
+            try:
+                bbox = [float(x) for x in parts]
+            except ValueError:
+                abort(400)
+        data = zone.zones_geojson(equipment_id, bbox=bbox, zoom=zoom)
+        return jsonify(data)
+
+    @app.route(
+        '/equipment/<int:equipment_id>/points.geojson',
+        endpoint='equipment_points_geojson'
+    )
+    @login_required
+    def equipment_points_geojson(equipment_id):
+        Equipment.query.get_or_404(equipment_id)
+        bbox_param = request.args.get('bbox')
+        bbox = None
+        if bbox_param:
+            parts = [p.strip() for p in bbox_param.split(',')]
+            if len(parts) != 4:
+                abort(400)
+            try:
+                bbox = [float(x) for x in parts]
+            except ValueError:
+                abort(400)
+        data = zone.positions_geojson(equipment_id, bbox=bbox)
+        return jsonify(data)
 
     # Planification de la tâche quotidienne à 2h du matin
     scheduler = BackgroundScheduler()

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>{{ equipment.name }} - Détails</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
 </head>
 <body class="p-4">
   <div class="container">
@@ -18,7 +19,7 @@
     {% if zones %}
     <style>
       .zone-row { cursor: pointer; }
-      #map-container { height: 70vh; }
+      #map { height: 70vh; }
     </style>
     <div class="row">
       <div class="col-md-4 mb-4">
@@ -39,9 +40,7 @@
       <div class="col-md-8">
         <h2>Carte des passages</h2>
         <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
-        <div id="map-container">
-          {{ map_html|safe }}
-        </div>
+        <div id="map"></div>
       </div>
     </div>
     {% else %}
@@ -49,72 +48,109 @@
     {% endif %}
   </div>
 
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script>
+    let map;
+    let zoneLayer;
+    let pointsLayer;
+    let dateLayers = {};
+    let ignoreMove = false;
+
     function highlightDate(date) {
-      const rows = document.querySelectorAll('.zone-row');
-      rows.forEach(r => {
+      document.querySelectorAll('.zone-row').forEach(r => {
         r.classList.toggle('table-primary', r.dataset.date === date);
       });
-
-      const iframe = document.querySelector('#map-container iframe');
-      if (!iframe || !iframe.contentWindow) return;
-      const win = iframe.contentWindow;
-      if (!win.dateLayers) return;
-
-      Object.values(win.dateLayers).forEach(lst => {
-        lst.forEach(layer => layer.setStyle({weight: 1}));
-      });
-      if (win.dateLayers[date]) {
-        const bounds = win.L.latLngBounds();
-        win.dateLayers[date].forEach(layer => {
-          layer.setStyle({weight: 4});
-          if (layer.getBounds) bounds.extend(layer.getBounds());
-          if (layer.bringToFront) layer.bringToFront();
+      Object.values(dateLayers).flat().forEach(l => l.setStyle({ weight: 1 }));
+      if (dateLayers[date]) {
+        const zoneBounds = L.latLngBounds();
+        dateLayers[date].forEach(l => {
+          l.setStyle({ weight: 4 });
+          if (l.getBounds) zoneBounds.extend(l.getBounds());
+          l.bringToFront();
         });
-        if (win.leafletMap && bounds.isValid()) {
-          win.leafletMap.fitBounds(bounds, { maxZoom: 17 });
+        if (zoneBounds.isValid()) {
+          ignoreMove = true;
+          map.fitBounds(zoneBounds, { maxZoom: 17 });
+          map.once('moveend', () => { ignoreMove = false; });
+        }
+        if (dateLayers[date][0]) {
+          dateLayers[date][0].openPopup();
         }
       }
     }
 
-    function setupInteractions() {
+    function loadZones() {
+      const b = map.getBounds();
+      const bbox = [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
+      const url = "{{ url_for('equipment_zones_geojson', equipment_id=equipment.id) }}" + `?bbox=${bbox}&zoom=${map.getZoom()}`;
+      fetch(url)
+        .then(r => r.json())
+        .then(data => {
+          zoneLayer.clearLayers();
+          dateLayers = {};
+          zoneLayer.addData(data);
+          zoneLayer.eachLayer(layer => {
+            const props = layer.feature.properties;
+            const dates = props.dates;
+            const popup = `<b>Passages:</b> ${props.pass_count}` +
+                          `<br><b>Surface:</b> ${props.surface_ha.toFixed(2)} ha` +
+                          `<br><b>Dates:</b> ${dates.join(', ')}`;
+            layer.bindPopup(popup);
+            dates.forEach(d => {
+              dateLayers[d] = dateLayers[d] || [];
+              dateLayers[d].push(layer);
+            });
+            layer.on('click', () => highlightDate(dates[0]));
+          });
+        });
+    }
+
+    function loadPoints() {
+      const b = map.getBounds();
+      const bbox = [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
+      const url = "{{ url_for('equipment_points_geojson', equipment_id=equipment.id) }}" + `?bbox=${bbox}`;
+      fetch(url)
+        .then(r => r.json())
+        .then(data => {
+          pointsLayer.clearLayers();
+          L.geoJSON(data, {
+            pointToLayer: (f, latlng) => L.circleMarker(latlng, { radius: 2, color: '#555', weight: 1 })
+          }).addTo(pointsLayer);
+        });
+    }
+
+    function setupMap() {
+      map = L.map('map').setView([{{ center[0] }}, {{ center[1] }}], 12);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors'
+      }).addTo(map);
+      const colors = ['#2b83ba', '#abdda4', '#ffffbf', '#fdae61', '#d7191c'];
+      function styleFeature(f) {
+        const count = f.properties.dates.length;
+        const idx = Math.min(count - 1, colors.length - 1);
+        return {
+          color: 'black',
+          weight: 1,
+          fillColor: colors[idx],
+          fillOpacity: 0.6
+        };
+      }
+      zoneLayer = L.geoJSON(null, { style: styleFeature }).addTo(map);
+      pointsLayer = L.layerGroup().addTo(map);
+      map.on('moveend', () => {
+        if (!ignoreMove) { loadZones(); loadPoints(); }
+      });
+      loadZones();
+      loadPoints();
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.zone-row').forEach(row => {
         row.addEventListener('click', () => highlightDate(row.dataset.date));
       });
-
-      const iframe = document.querySelector('#map-container iframe');
-      if (!iframe) return;
-      iframe.addEventListener('load', () => {
-        const win = iframe.contentWindow;
-        if (!win) return;
-        for (const key of Object.keys(win)) {
-          const obj = win[key];
-          if (obj && obj instanceof win.L.Map) {
-            win.leafletMap = obj;
-          }
-        }
-        win.dateLayers = {};
-        for (const key of Object.keys(win)) {
-          const obj = win[key];
-          if (obj && obj instanceof win.L.GeoJSON) {
-            obj.eachLayer(layer => {
-              const props = layer.feature && layer.feature.properties;
-              if (props && props.dates) {
-                props.dates.forEach(d => {
-                  win.dateLayers[d] = win.dateLayers[d] || [];
-                  win.dateLayers[d].push(layer);
-                });
-                layer.on('click', () => {
-                  if (window.highlightDate) window.highlightDate(props.dates[0]);
-                });
-              }
-            });
-          }
-        }
-      });
-    }
-
-    window.addEventListener('DOMContentLoaded', setupInteractions);
+      setupMap();
+      {% if bounds %}map.fitBounds([[{{ bounds[0] }}, {{ bounds[1] }}], [{{ bounds[2] }}, {{ bounds[3] }}]]);{% endif %}
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify polygons at lower zoom levels
- aggregate overlapping daily zones in the API
- display popups with pass count and dates on the equipment map
- test aggregation of overlapping zones
- keep menu visible when highlighting zones and fit map to all zones on page load

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68896f4965248322b449285c55782b8a