### PR TITLE
Add synchronized zone selection between table and map

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -101,6 +101,7 @@
         skipFetch = true;
         map.once('moveend', () => {
           skipFetch = false;
+          fetchData();
           if (ids.length === 1 && featureLayers[ids[0]]) {
             featureLayers[ids[0]].openPopup();
           }

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -76,29 +76,38 @@
       });
     }
 
-    function highlightRow(date) {
+    function highlightRows(dates) {
       const rows = document.querySelectorAll('.zone-row');
       rows.forEach(r => {
-        r.classList.toggle('table-primary', r.dataset.date === date);
+        r.classList.toggle('table-primary', dates.includes(r.dataset.date));
       });
     }
 
-    function highlightZone(id) {
-      zoneLayer.eachLayer(l => l.setStyle({weight: 1}));
-      const layer = featureLayers[id];
-      if (layer) {
-        layer.setStyle({weight: 4});
-        if (layer.getBounds && layer.getBounds().isValid()) {
-          const bounds = layer.getBounds();
-          skipFetch = true;
-          map.once('moveend', () => {
-            skipFetch = false;
-            layer.openPopup();
-          });
-          map.fitBounds(bounds, { maxZoom: 17 });
-        } else {
-          layer.openPopup();
+    function highlightZone(ids) {
+      zoneLayer.eachLayer(l => l.setStyle({ weight: 1 }));
+      ids = Array.isArray(ids) ? ids : [ids];
+      let bounds;
+      ids.forEach(id => {
+        const layer = featureLayers[id];
+        if (layer) {
+          layer.setStyle({ weight: 4 });
+          if (layer.getBounds && layer.getBounds().isValid()) {
+            const b = layer.getBounds();
+            bounds = bounds ? bounds.extend(b) : b.clone();
+          }
         }
+      });
+      if (bounds) {
+        skipFetch = true;
+        map.once('moveend', () => {
+          skipFetch = false;
+          if (ids.length === 1 && featureLayers[ids[0]]) {
+            featureLayers[ids[0]].openPopup();
+          }
+        });
+        map.fitBounds(bounds, { maxZoom: 17 });
+      } else if (ids.length === 1 && featureLayers[ids[0]]) {
+        featureLayers[ids[0]].openPopup();
       }
     }
 
@@ -142,7 +151,7 @@
           if (dates) html += `<br><b>Dates:</b> ${dates}`;
           layer.bindPopup(html);
           layer.on('click', () => {
-            highlightRow(feature.properties.dates[0]);
+            highlightRows(feature.properties.dates);
             highlightZone(feature.id);
           });
         }
@@ -180,10 +189,11 @@
       document.querySelectorAll('.zone-row').forEach(row => {
         row.addEventListener('click', () => {
           const date = row.dataset.date;
-          highlightRow(date);
+          highlightRows([date]);
           const layers = dateLayers[date] || [];
           if (layers.length) {
-            highlightZone(layers[0].feature.id);
+            const ids = layers.map(l => l.feature.id);
+            highlightZone(ids);
           }
         });
       });

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -128,3 +128,15 @@ def test_equipment_page_contains_highlight_zone():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "function highlightZone" in html
+
+
+def test_equipment_page_contains_highlight_rows():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "function highlightRows" in html

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -128,6 +128,10 @@ def test_equipment_page_contains_highlight_zone():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "function highlightZone" in html
+    start = html.find("function highlightZone")
+    end = html.find("function fetchData")
+    snippet = html[start:end] if end != -1 else html[start:]
+    assert "fetchData()" in snippet
 
 
 def test_equipment_page_contains_highlight_rows():


### PR DESCRIPTION
## Summary
- link table rows to all polygons for the same date
- support multiple layers in highlightZone and highlightRows helper
- test for presence of new highlightRows function

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_688bc3bafee08322844c91dbf668198f