### PR TITLE
Synchronise zone selection between table and map

### DIFF
--- a/app.py
+++ b/app.py
@@ -388,9 +388,18 @@ def create_app():
             .order_by(DailyZone.date.desc())
             .all()
         )
+        zone_bounds = {
+            z.id: zone.wkt_bounds(z.polygon_wkt)
+            for z in zones
+            if z.polygon_wkt
+        }
         bounds = zone.get_bounds_for_equipment(equipment_id)
         return render_template(
-            'equipment.html', equipment=eq, zones=zones, bounds=bounds
+            'equipment.html',
+            equipment=eq,
+            zones=zones,
+            bounds=bounds,
+            zone_bounds=zone_bounds,
         )
 
     @app.route('/equipment/<int:equipment_id>/zones.geojson')

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -32,7 +32,7 @@
           </thead>
           <tbody>
             {% for z in zones %}
-            <tr class="zone-row" data-date="{{ z.date }}">
+            <tr class="zone-row" data-date="{{ z.date }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
               <td>{{ z.date }}</td>
               <td>{{ z.surface_ha|round(2) }}</td>
             </tr>
@@ -101,10 +101,11 @@
         skipFetch = true;
         map.once('moveend', () => {
           skipFetch = false;
-          fetchData();
-          if (ids.length === 1 && featureLayers[ids[0]]) {
-            featureLayers[ids[0]].openPopup();
-          }
+          fetchData().then(() => {
+            if (ids.length === 1 && featureLayers[ids[0]]) {
+              featureLayers[ids[0]].openPopup();
+            }
+          });
         });
         map.fitBounds(bounds, { maxZoom: 17 });
       } else if (ids.length === 1 && featureLayers[ids[0]]) {
@@ -117,19 +118,20 @@
       const b = map.getBounds();
       const bbox = [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
       const zoom = map.getZoom();
-      fetch(`/equipment/${equipmentId}/zones.geojson?bbox=${bbox}&zoom=${zoom}`)
+      const zonesPromise = fetch(`/equipment/${equipmentId}/zones.geojson?bbox=${bbox}&zoom=${zoom}`)
         .then(r => r.json())
         .then(data => {
           zoneLayer.clearLayers();
           zoneLayer.addData(data);
           rebuildDateLayers();
         });
-      fetch(`/equipment/${equipmentId}/points.geojson?bbox=${bbox}&limit=5000`)
+      const pointsPromise = fetch(`/equipment/${equipmentId}/points.geojson?bbox=${bbox}&limit=5000`)
         .then(r => r.json())
         .then(data => {
           pointLayer.clearLayers();
           pointLayer.addData(data);
         });
+      return Promise.all([zonesPromise, pointsPromise]);
     }
 
     function setupMap() {
@@ -195,6 +197,23 @@
           if (layers.length) {
             const ids = layers.map(l => l.feature.id);
             highlightZone(ids);
+          } else if (row.dataset.bounds) {
+            const b = JSON.parse(row.dataset.bounds);
+            const bounds = L.latLngBounds(
+              [b[1], b[0]],
+              [b[3], b[2]]
+            );
+            skipFetch = true;
+            map.once('moveend', () => {
+              skipFetch = false;
+              fetchData().then(() => {
+                const newLayers = dateLayers[date] || [];
+                const ids = newLayers.map(l => l.feature.id);
+                highlightRows([date]);
+                if (ids.length) highlightZone(ids);
+              });
+            });
+            map.fitBounds(bounds, { maxZoom: 17 });
           }
         });
       });

--- a/zone.py
+++ b/zone.py
@@ -73,6 +73,17 @@ def invalidate_cache(equipment_id: int) -> None:
     _AGG_CACHE.pop(equipment_id, None)
 
 
+def wkt_bounds(polygon_wkt: str):
+    """Return bounding box (west, south, east, north) for a WKT polygon."""
+    from shapely import wkt
+
+    if not polygon_wkt:
+        return None
+    geom = wkt.loads(polygon_wkt)
+    geom_wgs = shp_transform(_transformer, geom)
+    return geom_wgs.bounds
+
+
 def get_aggregated_zones(equipment_id: int):
     """Retourne les zones agrégées pour un équipement, en cache."""
     if equipment_id not in _AGG_CACHE:


### PR DESCRIPTION
## Summary
- expose bounds for each daily zone and embed them in equipment.html
- add helper to compute bounds from WKT
- fetch map data asynchronously and zoom to zone when a table row is clicked

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_688bccd884a08322835c9d27a3d02641