### PR TITLE
Fix zone selection highlighting

### DIFF
--- a/app.py
+++ b/app.py
@@ -435,6 +435,7 @@ def create_app():
                 'id': str(idx),
                 'properties': {
                     'dates': z['dates'],
+                    'dz_ids': z.get('ids', []),
                     'count': len(z['dates']),
                     'surface_ha': round(geom.area / 1e4, 2),
                 },

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -32,7 +32,7 @@
           </thead>
           <tbody>
             {% for z in zones %}
-            <tr class="zone-row" data-date="{{ z.date }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
+            <tr class="zone-row" data-date="{{ z.date }}" data-zone-id="{{ z.id }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
               <td>{{ z.date }}</td>
               <td>{{ z.surface_ha|round(2) }}</td>
             </tr>
@@ -57,6 +57,7 @@
     let zoneLayer;
     let pointLayer;
     let dateLayers = {};
+    let dzIdLayers = {};
     let featureLayers = {};
     let skipFetch = false;
     const equipmentId = {{ equipment.id }};
@@ -65,21 +66,27 @@
 
     function rebuildDateLayers() {
       dateLayers = {};
+      dzIdLayers = {};
       featureLayers = {};
       zoneLayer.eachLayer(layer => {
         const dates = layer.feature.properties.dates;
+        const ids = layer.feature.properties.dz_ids || [];
         featureLayers[layer.feature.id] = layer;
         dates.forEach(d => {
           dateLayers[d] = dateLayers[d] || [];
           dateLayers[d].push(layer);
         });
+        ids.forEach(i => {
+          dzIdLayers[i] = dzIdLayers[i] || [];
+          dzIdLayers[i].push(layer);
+        });
       });
     }
 
-    function highlightRows(dates) {
+    function highlightRows(ids) {
       const rows = document.querySelectorAll('.zone-row');
       rows.forEach(r => {
-        r.classList.toggle('table-primary', dates.includes(r.dataset.date));
+        r.classList.toggle('table-primary', ids.includes(parseInt(r.dataset.zoneId)));
       });
     }
 
@@ -154,8 +161,14 @@
           if (dates) html += `<br><b>Dates:</b> ${dates}`;
           layer.bindPopup(html);
           layer.on('click', () => {
-            highlightRows(feature.properties.dates);
-            highlightZone(feature.id);
+            const ids = feature.properties.dz_ids || [];
+            const zoneIds = [];
+            ids.forEach(zid => {
+              const layers = dzIdLayers[zid] || [];
+              layers.forEach(l => zoneIds.push(l.feature.id));
+            });
+            highlightRows(ids.map(i => parseInt(i)));
+            highlightZone(zoneIds.length ? zoneIds : feature.id);
           });
         }
       }).addTo(map);
@@ -191,9 +204,9 @@
     function setupInteractions() {
       document.querySelectorAll('.zone-row').forEach(row => {
         row.addEventListener('click', () => {
-          const date = row.dataset.date;
-          highlightRows([date]);
-          const layers = dateLayers[date] || [];
+          const zoneId = parseInt(row.dataset.zoneId);
+          highlightRows([zoneId]);
+          const layers = dzIdLayers[zoneId] || [];
           if (layers.length) {
             const ids = layers.map(l => l.feature.id);
             highlightZone(ids);
@@ -207,9 +220,9 @@
             map.once('moveend', () => {
               skipFetch = false;
               fetchData().then(() => {
-                const newLayers = dateLayers[date] || [];
+                const newLayers = dzIdLayers[zoneId] || [];
                 const ids = newLayers.map(l => l.feature.id);
-                highlightRows([date]);
+                highlightRows([zoneId]);
                 if (ids.length) highlightZone(ids);
               });
             });

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -101,6 +101,7 @@ def test_zones_geojson_endpoint():
     data = resp.get_json()
     assert data["features"]
     assert "surface_ha" in data["features"][0]["properties"]
+    assert "dz_ids" in data["features"][0]["properties"]
 
 
 def test_points_geojson_endpoint():
@@ -144,3 +145,15 @@ def test_equipment_page_contains_highlight_rows():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "function highlightRows" in html
+
+
+def test_zone_rows_have_ids():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert 'data-zone-id="' in html


### PR DESCRIPTION
## Summary
- track DailyZone IDs when aggregating zones
- expose `dz_ids` in GeoJSON output
- map table rows to zone IDs and improve JS highlighting
- update tests for new output and DOM attributes

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=. > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_688bdd2e476883229155bca02ea3ed44