### PR TITLE
Show pass counts on equipment page

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -28,12 +28,17 @@
       <div class="col-md-4 mb-4">
         <table id="zones-table" class="table table-striped">
           <thead>
-            <tr><th>Date</th><th>Surface (ha)</th></tr>
+            <tr>
+              <th>Date(s)</th>
+              <th>Passages</th>
+              <th>Hectares travaillés</th>
+            </tr>
           </thead>
           <tbody>
             {% for z in zones %}
             <tr class="zone-row" data-date="{{ z.date }}" data-zone-id="{{ z.id }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
               <td>{{ z.date }}</td>
+              <td>{{ z.pass_count }}</td>
               <td>{{ z.surface_ha|round(2) }}</td>
             </tr>
             {% endfor %}

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -157,3 +157,17 @@ def test_zone_rows_have_ids():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert 'data-zone-id="' in html
+
+
+def test_equipment_table_columns():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "Date(s)" in html
+    assert "Passages" in html
+    assert "Hectares travaillés" in html


### PR DESCRIPTION
## Summary
- show `Passages` and `Hectares travaillés` columns on the equipment detail page
- add test validating the new table headers

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=. > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_688c07c307488322b476cc5b11433cfb