### PR TITLE
Synchronize equipment table with map data

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from flask_login import (
 )
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from models import db, User, Equipment, Position, DailyZone, Config
+from models import db, User, Equipment, Position, Config
 import zone
 
 from datetime import datetime
@@ -382,17 +382,17 @@ def create_app():
     @login_required
     def equipment_detail(equipment_id):
         eq = Equipment.query.get_or_404(equipment_id)
-        zones = (
-            DailyZone.query
-            .filter_by(equipment_id=equipment_id)
-            .order_by(DailyZone.date.desc())
-            .all()
-        )
-        zone_bounds = {
-            z.id: zone.wkt_bounds(z.polygon_wkt)
-            for z in zones
-            if z.polygon_wkt
-        }
+        agg = zone.get_aggregated_zones(equipment_id)
+        zones = []
+        zone_bounds = {}
+        for idx, z in enumerate(agg):
+            zones.append({
+                "id": idx,
+                "dates": ", ".join(sorted(set(z["dates"]))),
+                "pass_count": len(z["dates"]),
+                "surface_ha": z["geometry"].area / 1e4,
+            })
+            zone_bounds[idx] = zone.geom_bounds(z["geometry"])
         bounds = zone.get_bounds_for_equipment(equipment_id)
         return render_template(
             'equipment.html',

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ flake8
 pytest-cov
 pytest
 mypy
+beautifulsoup4

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -36,8 +36,8 @@
           </thead>
           <tbody>
             {% for z in zones %}
-            <tr class="zone-row" data-date="{{ z.date }}" data-zone-id="{{ z.id }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
-              <td>{{ z.date }}</td>
+            <tr class="zone-row" data-zone-id="{{ z.id }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
+              <td>{{ z.dates }}</td>
               <td>{{ z.pass_count }}</td>
               <td>{{ z.surface_ha|round(2) }}</td>
             </tr>
@@ -62,7 +62,6 @@
     let zoneLayer;
     let pointLayer;
     let dateLayers = {};
-    let dzIdLayers = {};
     let featureLayers = {};
     let skipFetch = false;
     const equipmentId = {{ equipment.id }};
@@ -71,19 +70,13 @@
 
     function rebuildDateLayers() {
       dateLayers = {};
-      dzIdLayers = {};
       featureLayers = {};
       zoneLayer.eachLayer(layer => {
         const dates = layer.feature.properties.dates;
-        const ids = layer.feature.properties.dz_ids || [];
         featureLayers[layer.feature.id] = layer;
         dates.forEach(d => {
           dateLayers[d] = dateLayers[d] || [];
           dateLayers[d].push(layer);
-        });
-        ids.forEach(i => {
-          dzIdLayers[i] = dzIdLayers[i] || [];
-          dzIdLayers[i].push(layer);
         });
       });
     }
@@ -166,14 +159,9 @@
           if (dates) html += `<br><b>Dates:</b> ${dates}`;
           layer.bindPopup(html);
           layer.on('click', () => {
-            const ids = feature.properties.dz_ids || [];
-            const zoneIds = [];
-            ids.forEach(zid => {
-              const layers = dzIdLayers[zid] || [];
-              layers.forEach(l => zoneIds.push(l.feature.id));
-            });
-            highlightRows(ids.map(i => parseInt(i)));
-            highlightZone(zoneIds.length ? zoneIds : feature.id);
+            const zoneId = parseInt(feature.id);
+            highlightRows([zoneId]);
+            highlightZone(zoneId);
           });
         }
       }).addTo(map);
@@ -211,10 +199,9 @@
         row.addEventListener('click', () => {
           const zoneId = parseInt(row.dataset.zoneId);
           highlightRows([zoneId]);
-          const layers = dzIdLayers[zoneId] || [];
-          if (layers.length) {
-            const ids = layers.map(l => l.feature.id);
-            highlightZone(ids);
+          const layer = featureLayers[zoneId];
+          if (layer) {
+            highlightZone(zoneId);
           } else if (row.dataset.bounds) {
             const b = JSON.parse(row.dataset.bounds);
             const bounds = L.latLngBounds(
@@ -225,10 +212,8 @@
             map.once('moveend', () => {
               skipFetch = false;
               fetchData().then(() => {
-                const newLayers = dzIdLayers[zoneId] || [];
-                const ids = newLayers.map(l => l.feature.id);
                 highlightRows([zoneId]);
-                if (ids.length) highlightZone(ids);
+                if (featureLayers[zoneId]) highlightZone(zoneId);
               });
             });
             map.fitBounds(bounds, { maxZoom: 17 });

--- a/zone.py
+++ b/zone.py
@@ -84,6 +84,14 @@ def wkt_bounds(polygon_wkt: str):
     return geom_wgs.bounds
 
 
+def geom_bounds(geom):
+    """Return bounding box (west, south, east, north) for a geometry."""
+    if geom is None or geom.is_empty:
+        return None
+    geom_wgs = shp_transform(_transformer, geom)
+    return geom_wgs.bounds
+
+
 def get_aggregated_zones(equipment_id: int):
     """Retourne les zones agrégées pour un équipement, en cache."""
     if equipment_id not in _AGG_CACHE:


### PR DESCRIPTION
## Summary
- compute aggregated zones in the `equipment_detail` route
- expose geometry bounds through new `geom_bounds` helper
- update equipment template to list aggregated zones
- adjust JavaScript interactions for new zone identifiers
- update tests and add check for aggregated pass count
- include BeautifulSoup dependency for tests

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_688c0d2bcc1c83228c3027431f281980