### PR TITLE
Fix initial zone centering

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -112,7 +112,7 @@
             }
           });
         });
-        map.fitBounds(bounds, { maxZoom: 17 });
+        map.fitBounds(bounds, { maxZoom: 19 });
       } else if (ids.length === 1 && featureLayers[ids[0]]) {
         featureLayers[ids[0]].openPopup();
       }
@@ -216,14 +216,18 @@
                 if (featureLayers[zoneId]) highlightZone(zoneId);
               });
             });
-            map.fitBounds(bounds, { maxZoom: 17 });
+            map.fitBounds(bounds, { maxZoom: 19 });
           }
         });
       });
       setupMap();
     }
 
-    window.addEventListener('DOMContentLoaded', setupInteractions);
+    if (document.readyState === 'loading') {
+      window.addEventListener('DOMContentLoaded', setupInteractions);
+    } else {
+      setupInteractions();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix interactive initialization when DOMContentLoaded already fired
- increase max zoom and center map when clicking zones

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=. > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688c19fb406083229cf9c78269efd57f