### PR TITLE
Fix mobile map panning and zone selection

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -91,7 +91,7 @@
       });
     }
 
-    function highlightZone(ids) {
+    function highlightZone(ids, skipZoom = false) {
       zoneLayer.eachLayer(l => l.setStyle({ weight: 1 }));
       ids = Array.isArray(ids) ? ids : [ids];
       let bounds;
@@ -99,13 +99,13 @@
         const layer = featureLayers[id];
         if (layer) {
           layer.setStyle({ weight: 4 });
-          if (layer.getBounds && layer.getBounds().isValid()) {
+          if (!skipZoom && layer.getBounds && layer.getBounds().isValid()) {
             const b = layer.getBounds();
             bounds = bounds ? bounds.extend(b) : b.clone();
           }
         }
       });
-      if (bounds) {
+      if (bounds && !skipZoom) {
         skipFetch = true;
         map.once('moveend', () => {
           skipFetch = false;
@@ -213,13 +213,16 @@
             );
             skipFetch = true;
             map.once('moveend', () => {
+              if (map.getZoom() < 17) {
+                map.setZoom(17, { animate: false });
+              }
               skipFetch = false;
               fetchData().then(() => {
                 highlightRows([zoneId]);
-                if (featureLayers[zoneId]) highlightZone(zoneId);
+                if (featureLayers[zoneId]) highlightZone(zoneId, true);
               });
             });
-            map.fitBounds(bounds, { maxZoom: 17, animate: false });
+            map.fitBounds(bounds, { animate: false });
           }
         });
       });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -67,6 +67,7 @@
     let dateLayers = {};
     let featureLayers = {};
     let skipFetch = false;
+    let fetchToken = 0;
     const equipmentId = {{ equipment.id }};
     const initialBounds = {{ bounds|tojson }};
     const colors = ['#2b83ba', '#abdda4', '#ffffbf', '#fdae61', '#d7191c'];
@@ -138,23 +139,22 @@
 
 
     function fetchData() {
+      const token = ++fetchToken;
       const b = map.getBounds();
       const bbox = [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
       const zoom = map.getZoom();
       const zonesPromise = fetch(`/equipment/${equipmentId}/zones.geojson?bbox=${bbox}&zoom=${zoom}`)
-        .then(r => r.json())
-        .then(data => {
-          zoneLayer.clearLayers();
-          zoneLayer.addData(data);
-          rebuildDateLayers();
-        });
+        .then(r => r.json());
       const pointsPromise = fetch(`/equipment/${equipmentId}/points.geojson?bbox=${bbox}&limit=5000`)
-        .then(r => r.json())
-        .then(data => {
-          pointLayer.clearLayers();
-          pointLayer.addData(data);
-        });
-      return Promise.all([zonesPromise, pointsPromise]);
+        .then(r => r.json());
+      return Promise.all([zonesPromise, pointsPromise]).then(([zoneData, pointData]) => {
+        if (token !== fetchToken) return;
+        zoneLayer.clearLayers();
+        zoneLayer.addData(zoneData);
+        rebuildDateLayers();
+        pointLayer.clearLayers();
+        pointLayer.addData(pointData);
+      });
     }
 
     function setupMap() {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -212,12 +212,14 @@
               [b[3], b[2]]
             );
             skipFetch = true;
-            map.fitBounds(bounds, { maxZoom: 17, animate: false });
-            fetchData().then(() => {
+            map.once('moveend', () => {
               skipFetch = false;
-              highlightRows([zoneId]);
-              if (featureLayers[zoneId]) highlightZone(zoneId);
+              fetchData().then(() => {
+                highlightRows([zoneId]);
+                if (featureLayers[zoneId]) highlightZone(zoneId);
+              });
             });
+            map.fitBounds(bounds, { maxZoom: 17, animate: false });
           }
         });
       });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -68,6 +68,7 @@
     let featureLayers = {};
     let skipFetch = false;
     let fetchToken = 0;
+    let zonesLoaded = false;
     const equipmentId = {{ equipment.id }};
     const initialBounds = {{ bounds|tojson }};
     const colors = ['#2b83ba', '#abdda4', '#ffffbf', '#fdae61', '#d7191c'];
@@ -140,21 +141,30 @@
 
     function fetchData() {
       const token = ++fetchToken;
+      const promises = [];
+      if (!zonesLoaded) {
+        const zp = fetch(`/equipment/${equipmentId}/zones.geojson?zoom=17`)
+          .then(r => r.json())
+          .then(zoneData => {
+            if (token !== fetchToken) return;
+            zoneLayer.clearLayers();
+            zoneLayer.addData(zoneData);
+            rebuildDateLayers();
+            zonesLoaded = true;
+          });
+        promises.push(zp);
+      }
       const b = map.getBounds();
       const bbox = [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
-      const zoom = map.getZoom();
-      const zonesPromise = fetch(`/equipment/${equipmentId}/zones.geojson?bbox=${bbox}&zoom=${zoom}`)
-        .then(r => r.json());
-      const pointsPromise = fetch(`/equipment/${equipmentId}/points.geojson?bbox=${bbox}&limit=5000`)
-        .then(r => r.json());
-      return Promise.all([zonesPromise, pointsPromise]).then(([zoneData, pointData]) => {
-        if (token !== fetchToken) return;
-        zoneLayer.clearLayers();
-        zoneLayer.addData(zoneData);
-        rebuildDateLayers();
-        pointLayer.clearLayers();
-        pointLayer.addData(pointData);
-      });
+      const pp = fetch(`/equipment/${equipmentId}/points.geojson?bbox=${bbox}&limit=5000`)
+        .then(r => r.json())
+        .then(pointData => {
+          if (token !== fetchToken) return;
+          pointLayer.clearLayers();
+          pointLayer.addData(pointData);
+        });
+      promises.push(pp);
+      return Promise.all(promises);
     }
 
     function setupMap() {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -128,8 +128,8 @@
         if (map.getBounds().contains(bounds)) {
           doZoom();
         } else {
-          map.once('moveend', doZoom);
           map.fitBounds(bounds, { animate: false });
+          doZoom();
         }
       } else if (ids.length === 1 && featureLayers[ids[0]]) {
         featureLayers[ids[0]].openPopup();
@@ -245,8 +245,8 @@
             if (map.getBounds().contains(bounds)) {
               doZoom();
             } else {
-              map.once('moveend', doZoom);
               map.fitBounds(bounds, { animate: false });
+              doZoom();
             }
           }
         });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -20,7 +20,10 @@
     {% if zones %}
     <style>
       .zone-row { cursor: pointer; }
-      #map-container { height: 70vh; }
+      #map-container {
+        height: 70vh;
+        touch-action: none;
+      }
       .legend { background: white; padding: 6px 8px; line-height: 18px; color: #555; }
       .legend i { width: 18px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; }
     </style>
@@ -209,14 +212,12 @@
               [b[3], b[2]]
             );
             skipFetch = true;
-            map.once('moveend', () => {
+            map.fitBounds(bounds, { maxZoom: 17, animate: false });
+            fetchData().then(() => {
               skipFetch = false;
-              fetchData().then(() => {
-                highlightRows([zoneId]);
-                if (featureLayers[zoneId]) highlightZone(zoneId);
-              });
+              highlightRows([zoneId]);
+              if (featureLayers[zoneId]) highlightZone(zoneId);
             });
-            map.fitBounds(bounds, { maxZoom: 17 });
           }
         });
       });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -101,7 +101,9 @@
           layer.setStyle({ weight: 4 });
           if (!skipZoom && layer.getBounds && layer.getBounds().isValid()) {
             const b = layer.getBounds();
-            bounds = bounds ? bounds.extend(b) : b.clone();
+            bounds = bounds
+              ? bounds.extend(b)
+              : L.latLngBounds(b.getSouthWest(), b.getNorthEast());
           }
         }
       });
@@ -117,7 +119,7 @@
         };
         const doZoom = () => {
           if (map.getZoom() < 17) {
-            map.once('moveend', finish);
+            map.once('zoomend', finish);
             map.setZoom(17, { animate: false });
           } else {
             finish();
@@ -234,7 +236,7 @@
             };
             const doZoom = () => {
               if (map.getZoom() < 17) {
-                map.once('moveend', finish);
+                map.once('zoomend', finish);
                 map.setZoom(17, { animate: false });
               } else {
                 finish();

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -107,15 +107,23 @@
       });
       if (bounds && !skipZoom) {
         skipFetch = true;
-        map.once('moveend', () => {
+        const finish = () => {
           skipFetch = false;
           fetchData().then(() => {
             if (ids.length === 1 && featureLayers[ids[0]]) {
               featureLayers[ids[0]].openPopup();
             }
           });
+        };
+        map.once('moveend', () => {
+          if (map.getZoom() < 17) {
+            map.once('moveend', finish);
+            map.setZoom(17, { animate: false });
+          } else {
+            finish();
+          }
         });
-        map.fitBounds(bounds, { maxZoom: 17 });
+        map.fitBounds(bounds, { animate: false });
       } else if (ids.length === 1 && featureLayers[ids[0]]) {
         featureLayers[ids[0]].openPopup();
       }

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -127,8 +127,14 @@
             finish();
           }
         };
+        const center = bounds.getCenter();
         if (map.getBounds().contains(bounds)) {
-          ensureZoom();
+          if (map.getCenter().equals(center)) {
+            ensureZoom();
+          } else {
+            map.once('moveend', ensureZoom);
+            map.panTo(center, { animate: false });
+          }
         } else {
           map.once('moveend', ensureZoom);
           map.fitBounds(bounds, { animate: false });
@@ -252,8 +258,14 @@
                 finish();
               }
             };
+            const center = bounds.getCenter();
             if (map.getBounds().contains(bounds)) {
-              ensureZoom();
+              if (map.getCenter().equals(center)) {
+                ensureZoom();
+              } else {
+                map.once('moveend', ensureZoom);
+                map.panTo(center, { animate: false });
+              }
             } else {
               map.once('moveend', ensureZoom);
               map.fitBounds(bounds, { animate: false });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -117,7 +117,7 @@
             }
           });
         };
-        const doZoom = () => {
+        const ensureZoom = () => {
           if (map.getZoom() < 17) {
             map.once('zoomend', finish);
             map.setZoom(17, { animate: false });
@@ -126,10 +126,10 @@
           }
         };
         if (map.getBounds().contains(bounds)) {
-          doZoom();
+          ensureZoom();
         } else {
+          map.once('moveend', ensureZoom);
           map.fitBounds(bounds, { animate: false });
-          doZoom();
         }
       } else if (ids.length === 1 && featureLayers[ids[0]]) {
         featureLayers[ids[0]].openPopup();
@@ -234,7 +234,7 @@
                 if (featureLayers[zoneId]) highlightZone(zoneId, true);
               });
             };
-            const doZoom = () => {
+            const ensureZoom = () => {
               if (map.getZoom() < 17) {
                 map.once('zoomend', finish);
                 map.setZoom(17, { animate: false });
@@ -243,10 +243,10 @@
               }
             };
             if (map.getBounds().contains(bounds)) {
-              doZoom();
+              ensureZoom();
             } else {
+              map.once('moveend', ensureZoom);
               map.fitBounds(bounds, { animate: false });
-              doZoom();
             }
           }
         });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -115,15 +115,20 @@
             }
           });
         };
-        map.once('moveend', () => {
+        const doZoom = () => {
           if (map.getZoom() < 17) {
             map.once('moveend', finish);
             map.setZoom(17, { animate: false });
           } else {
             finish();
           }
-        });
-        map.fitBounds(bounds, { animate: false });
+        };
+        if (map.getBounds().contains(bounds)) {
+          doZoom();
+        } else {
+          map.once('moveend', doZoom);
+          map.fitBounds(bounds, { animate: false });
+        }
       } else if (ids.length === 1 && featureLayers[ids[0]]) {
         featureLayers[ids[0]].openPopup();
       }
@@ -227,15 +232,20 @@
                 if (featureLayers[zoneId]) highlightZone(zoneId, true);
               });
             };
-            map.once('moveend', () => {
+            const doZoom = () => {
               if (map.getZoom() < 17) {
                 map.once('moveend', finish);
                 map.setZoom(17, { animate: false });
               } else {
                 finish();
               }
-            });
-            map.fitBounds(bounds, { animate: false });
+            };
+            if (map.getBounds().contains(bounds)) {
+              doZoom();
+            } else {
+              map.once('moveend', doZoom);
+              map.fitBounds(bounds, { animate: false });
+            }
           }
         });
       });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -212,15 +212,20 @@
               [b[3], b[2]]
             );
             skipFetch = true;
-            map.once('moveend', () => {
-              if (map.getZoom() < 17) {
-                map.setZoom(17, { animate: false });
-              }
+            const finish = () => {
               skipFetch = false;
               fetchData().then(() => {
                 highlightRows([zoneId]);
                 if (featureLayers[zoneId]) highlightZone(zoneId, true);
               });
+            };
+            map.once('moveend', () => {
+              if (map.getZoom() < 17) {
+                map.once('moveend', finish);
+                map.setZoom(17, { animate: false });
+              } else {
+                finish();
+              }
             });
             map.fitBounds(bounds, { animate: false });
           }

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -273,3 +273,17 @@ def test_fetch_data_uses_token():
     html = resp.data.decode()
     assert "let fetchToken" in html
     assert "token !== fetchToken" in html
+
+
+def test_zones_loaded_once_on_page_load():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "zonesLoaded" in html
+    assert "if (!zonesLoaded)" in html
+    assert "zones.geojson?zoom=17" in html

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -176,6 +176,7 @@ def test_row_click_uses_instant_zoom():
     html = resp.data.decode()
     assert "animate: false" in html
     assert "fitBounds(bounds, { animate: false" in html
+    assert "once('moveend', ensureZoom" in html
     assert "once('zoomend', finish" in html
     assert "fetchData().then" in html
 

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -175,8 +175,9 @@ def test_row_click_uses_instant_zoom():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "animate: false" in html
-    assert "moveend" in html
+    assert "fitBounds(bounds, { animate: false" in html
     assert "once('zoomend', finish" in html
+    assert "fetchData().then" in html
 
 
 def test_row_click_enforces_min_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -260,3 +260,16 @@ def test_table_shows_aggregated_pass_count():
     assert rows
     cells = rows[0].find_all("td")
     assert cells[1].text.strip() == "2"
+
+
+def test_fetch_data_uses_token():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "let fetchToken" in html
+    assert "token !== fetchToken" in html

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -176,6 +176,7 @@ def test_row_click_uses_instant_zoom():
     html = resp.data.decode()
     assert "animate: false" in html
     assert "moveend" in html
+    assert "once('zoomend', finish" in html
 
 
 def test_row_click_enforces_min_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -181,6 +181,18 @@ def test_row_click_uses_instant_zoom():
     assert "fetchData().then" in html
 
 
+def test_row_click_recenters_when_visible():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "panTo(center, { animate: false" in html
+
+
 def test_row_click_enforces_min_zoom():
     app = make_app()
     client = app.test_client()

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -153,6 +153,30 @@ def test_equipment_page_contains_highlight_rows():
     assert "function highlightRows" in html
 
 
+def test_map_container_has_touch_action():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "touch-action: none" in html
+
+
+def test_row_click_uses_instant_zoom():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "animate: false" in html
+
+
 def test_zone_rows_have_ids():
     app = make_app()
     client = app.test_client()

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -203,6 +203,18 @@ def test_highlight_zone_skip_zoom_parameter():
     assert "highlightZone(zoneId, true)" in html
 
 
+def test_bounds_check_before_zooming():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "getBounds().contains" in html
+
+
 def test_zone_rows_have_ids():
     app = make_app()
     client = app.test_client()

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -178,6 +178,31 @@ def test_row_click_uses_instant_zoom():
     assert "moveend" in html
 
 
+def test_row_click_enforces_min_zoom():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "setZoom(17" in html
+
+
+def test_highlight_zone_skip_zoom_parameter():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "skipZoom" in html
+    assert "highlightZone(zoneId, true)" in html
+
+
 def test_zone_rows_have_ids():
     app = make_app()
     client = app.test_client()

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -175,6 +175,7 @@ def test_row_click_uses_instant_zoom():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "animate: false" in html
+    assert "moveend" in html
 
 
 def test_zone_rows_have_ids():


### PR DESCRIPTION
## Summary
- allow single finger map panning on mobile
- load zones immediately when selecting a row
- test for new styles and behaviour

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=. > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_688d0f06a0fc8322ad087d3ef8bf7cad