### PR TITLE
Réorganise la page équipement avec carte en plein écran

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -16,7 +16,6 @@
         <a href="{{ url_for('logout') }}" class="btn btn-sm btn-outline-secondary">Déconnexion</a>
       </div>
     </div>
-    <h2>Zones journalières</h2>
     {% if zones %}
     <style>
       .zone-row { cursor: pointer; }
@@ -27,32 +26,31 @@
       .legend { background: white; padding: 6px 8px; line-height: 18px; color: #555; }
       .legend i { width: 18px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; }
     </style>
-    <div class="row">
-      <div class="col-md-4 mb-4">
-        <table id="zones-table" class="table table-striped">
-          <thead>
-            <tr>
-              <th>Date(s)</th>
-              <th>Passages</th>
-              <th>Hectares travaillés</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for z in zones %}
-            <tr class="zone-row" data-zone-id="{{ z.id }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
-              <td>{{ z.dates }}</td>
-              <td>{{ z.pass_count }}</td>
-              <td>{{ z.surface_ha|round(2) }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      <div class="col-md-8">
-        <h2>Carte des passages</h2>
-        <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
-        <div id="map-container"></div>
-      </div>
+    <div class="w-100 mb-4">
+      <h2>Carte des passages</h2>
+      <p class="text-muted">Les couleurs indiquent le nombre de passages sur chaque zone.</p>
+      <div id="map-container"></div>
+    </div>
+    <h2>Zones journalières</h2>
+    <div class="w-100">
+      <table id="zones-table" class="table table-striped">
+        <thead>
+          <tr>
+            <th>Date(s)</th>
+            <th>Passages</th>
+            <th>Hectares travaillés</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for z in zones %}
+          <tr class="zone-row" data-zone-id="{{ z.id }}" data-bounds='{{ zone_bounds.get(z.id)|tojson }}'>
+            <td>{{ z.dates }}</td>
+            <td>{{ z.pass_count }}</td>
+            <td>{{ z.surface_ha|round(2) }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
     {% else %}
     <p>Aucune donnée disponible pour cet équipement.</p>

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -79,6 +79,8 @@ def test_equipment_detail_page_loads():
     assert resp.status_code == 200
     html = resp.data.decode()
     assert "map-container" in html
+    assert "zones-table" in html
+    assert html.index("map-container") < html.index("zones-table")
 
 
 def test_equipment_page_shows_legend():


### PR DESCRIPTION
## Résumé
- place la carte des passages en pleine largeur au-dessus du tableau des zones
- conserve les styles de la carte et simplifie la structure Bootstrap
- ajuste les tests pour vérifier la nouvelle disposition

## Tests
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_688dfafcbe648322ad65260c9a9cb457