### PR TITLE
Ajout du filtrage journalier des zones

### DIFF
--- a/app.py
+++ b/app.py
@@ -407,12 +407,13 @@ def create_app():
         eq = Equipment.query.get_or_404(equipment_id)
         year = request.args.get('year', type=int)
         month = request.args.get('month', type=int)
+        day = request.args.get('day', type=int)
         # Les zones sont agrégées globalement pour conserver des identifiants
         # stables entre la carte (non filtrée) et le tableau (filtré).
         agg_all = zone.get_aggregated_zones(equipment_id)
-        if year is not None or month is not None:
+        if year is not None or month is not None or day is not None:
             agg_period = zone.get_aggregated_zones(
-                equipment_id, year=year, month=month
+                equipment_id, year=year, month=month, day=day
             )
         else:
             agg_period = agg_all
@@ -454,6 +455,12 @@ def create_app():
         months = sorted(
             {d.month for d in dates if year is None or d.year == year}
         )
+        if year is not None and month is not None:
+            days = sorted(
+                {d.day for d in dates if d.year == year and d.month == month}
+            )
+        else:
+            days = []
 
         return render_template(
             'equipment.html',
@@ -463,8 +470,10 @@ def create_app():
             zone_bounds=zone_bounds,
             years=years,
             months=months,
+            days=days,
             year=year,
             month=month,
+            day=day,
         )
 
     @app.route('/equipment/<int:equipment_id>/zones.geojson')

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -43,10 +43,16 @@
           <option value="{{ y }}" {% if year == y %}selected{% endif %}>{{ y }}</option>
           {% endfor %}
         </select>
-        <select id="month-select" class="form-select form-select-sm">
+        <select id="month-select" class="form-select form-select-sm me-2">
           <option value="">Tous les mois</option>
           {% for m in months %}
           <option value="{{ m }}" {% if month == m %}selected{% endif %}>{{ '%02d' % m }}</option>
+          {% endfor %}
+        </select>
+        <select id="day-select" class="form-select form-select-sm" {% if not days %}disabled{% endif %}>
+          <option value="">Tous les jours</option>
+          {% for d in days %}
+          <option value="{{ d }}" {% if day == d %}selected{% endif %}>{{ '%02d' % d }}</option>
           {% endfor %}
         </select>
       </div>
@@ -262,14 +268,17 @@
     function setupPeriodSelectors() {
       const yearSel = document.getElementById('year-select');
       const monthSel = document.getElementById('month-select');
+      const daySel = document.getElementById('day-select');
       function updatePeriod() {
         const params = new URLSearchParams(window.location.search);
         if (yearSel.value) params.set('year', yearSel.value); else params.delete('year');
         if (monthSel.value) params.set('month', monthSel.value); else params.delete('month');
+        if (yearSel.value && monthSel.value && daySel.value) params.set('day', daySel.value); else params.delete('day');
         window.location.search = params.toString();
       }
       yearSel.addEventListener('change', updatePeriod);
       monthSel.addEventListener('change', updatePeriod);
+      daySel.addEventListener('change', updatePeriod);
     }
 
     function setupInteractions() {


### PR DESCRIPTION
## Summary
- support de la sélection par jour dans l'agrégation des zones
- ajout du sélecteur de jour et de la logique associée dans l'interface équipement
- couverture de tests pour le filtrage journalier et les nouveaux paramètres

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6890b8606d548322864be4652a8a49ae