### PR TITLE
Allow closing equipment panel by dragging anywhere

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -510,15 +510,15 @@
             if (dy > 0 && content.scrollTop === 0) {
               disableScroll();
               onDown(moveEvt, startClientY);
-              sheet.removeEventListener('pointermove', maybeDrag);
+              content.removeEventListener('pointermove', maybeDrag);
             } else if (Math.abs(dy) > 5) {
-              sheet.removeEventListener('pointermove', maybeDrag);
+              content.removeEventListener('pointermove', maybeDrag);
             }
           };
-          sheet.addEventListener('pointermove', maybeDrag);
-          sheet.addEventListener(
+          content.addEventListener('pointermove', maybeDrag);
+          content.addEventListener(
             'pointerup',
-            () => sheet.removeEventListener('pointermove', maybeDrag),
+            () => content.removeEventListener('pointermove', maybeDrag),
             { once: true }
           );
         } else {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -466,9 +466,9 @@
       let start = 0;
       let dragging = false;
 
-      function onDown(e) {
+      function onDown(e, initialY) {
         e.preventDefault();
-        startY = e.clientY;
+        startY = initialY;
         start = current;
         sheet.style.transition = 'none';
         dragging = true;
@@ -504,12 +504,12 @@
 
       sheet.addEventListener('pointerdown', e => {
         if (sheet.classList.contains('open')) {
-          const startY = e.clientY;
+          const startClientY = e.clientY;
           const maybeDrag = moveEvt => {
-            const dy = moveEvt.clientY - startY;
+            const dy = moveEvt.clientY - startClientY;
             if (dy > 0 && content.scrollTop === 0) {
               disableScroll();
-              onDown(moveEvt);
+              onDown(moveEvt, startClientY);
               sheet.removeEventListener('pointermove', maybeDrag);
             } else if (Math.abs(dy) > 5) {
               sheet.removeEventListener('pointermove', maybeDrag);
@@ -523,14 +523,14 @@
           );
         } else {
           disableScroll();
-          onDown(e);
+          onDown(e, e.clientY);
         }
       });
 
       handle.addEventListener('pointerdown', e => {
         e.stopPropagation();
         disableScroll();
-        onDown(e);
+        onDown(e, e.clientY);
       });
 
       sheet.addEventListener('click', () => {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -503,7 +503,25 @@
       }
 
       sheet.addEventListener('pointerdown', e => {
-        if (!sheet.classList.contains('open')) {
+        if (sheet.classList.contains('open')) {
+          const startY = e.clientY;
+          const maybeDrag = moveEvt => {
+            const dy = moveEvt.clientY - startY;
+            if (dy > 0 && content.scrollTop === 0) {
+              disableScroll();
+              onDown(moveEvt);
+              sheet.removeEventListener('pointermove', maybeDrag);
+            } else if (Math.abs(dy) > 5) {
+              sheet.removeEventListener('pointermove', maybeDrag);
+            }
+          };
+          sheet.addEventListener('pointermove', maybeDrag);
+          sheet.addEventListener(
+            'pointerup',
+            () => sheet.removeEventListener('pointermove', maybeDrag),
+            { once: true }
+          );
+        } else {
           disableScroll();
           onDown(e);
         }

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -466,25 +466,32 @@
       let start = 0;
       let dragging = false;
 
+      const supportPointer = 'PointerEvent' in window;
+      const startEvent = supportPointer ? 'pointerdown' : 'touchstart';
+      const moveEvent = supportPointer ? 'pointermove' : 'touchmove';
+      const endEvent = supportPointer ? 'pointerup' : 'touchend';
+
+      const getY = e => (supportPointer ? e.clientY : e.touches[0].clientY);
+
       function onDown(e, initialY) {
         e.preventDefault();
         startY = initialY;
         start = current;
         sheet.style.transition = 'none';
         dragging = true;
-        window.addEventListener('pointermove', onMove);
-        window.addEventListener('pointerup', onUp);
+        window.addEventListener(moveEvent, onMove, { passive: false });
+        window.addEventListener(endEvent, onUp);
       }
 
       function onMove(e) {
         if (!dragging) return;
         e.preventDefault();
-        const dy = e.clientY - startY;
+        const dy = getY(e) - startY;
         current = clamp(start + dy, 0, collapsed);
         sheet.style.transform = `translateY(${current}px)`;
       }
 
-      function onUp(e) {
+      function onUp() {
         if (!dragging) return;
         sheet.style.transition = '';
         if (current < collapsed / 2) {
@@ -498,39 +505,40 @@
         }
         sheet.style.transform = `translateY(${current}px)`;
         dragging = false;
-        window.removeEventListener('pointermove', onMove);
-        window.removeEventListener('pointerup', onUp);
+        window.removeEventListener(moveEvent, onMove);
+        window.removeEventListener(endEvent, onUp);
       }
 
-      sheet.addEventListener('pointerdown', e => {
+      sheet.addEventListener(startEvent, e => {
         if (sheet.classList.contains('open')) {
-          const startClientY = e.clientY;
+          const startClientY = getY(e);
           const maybeDrag = moveEvt => {
-            const dy = moveEvt.clientY - startClientY;
+            const dy = getY(moveEvt) - startClientY;
             if (dy > 0 && content.scrollTop === 0) {
+              moveEvt.preventDefault();
               disableScroll();
               onDown(moveEvt, startClientY);
-              content.removeEventListener('pointermove', maybeDrag);
+              content.removeEventListener(moveEvent, maybeDrag);
             } else if (Math.abs(dy) > 5) {
-              content.removeEventListener('pointermove', maybeDrag);
+              content.removeEventListener(moveEvent, maybeDrag);
             }
           };
-          content.addEventListener('pointermove', maybeDrag);
+          content.addEventListener(moveEvent, maybeDrag, { passive: false });
           content.addEventListener(
-            'pointerup',
-            () => content.removeEventListener('pointermove', maybeDrag),
+            endEvent,
+            () => content.removeEventListener(moveEvent, maybeDrag),
             { once: true }
           );
         } else {
           disableScroll();
-          onDown(e, e.clientY);
+          onDown(e, getY(e));
         }
       });
 
-      handle.addEventListener('pointerdown', e => {
+      handle.addEventListener(startEvent, e => {
         e.stopPropagation();
         disableScroll();
-        onDown(e, e.clientY);
+        onDown(e, getY(e));
       });
 
       sheet.addEventListener('click', () => {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -466,27 +466,19 @@
       let start = 0;
       let dragging = false;
 
-      const supportPointer = 'PointerEvent' in window;
-      const startEvent = supportPointer ? 'pointerdown' : 'touchstart';
-      const moveEvent = supportPointer ? 'pointermove' : 'touchmove';
-      const endEvent = supportPointer ? 'pointerup' : 'touchend';
-
-      const getY = e => (supportPointer ? e.clientY : e.touches[0].clientY);
-
-      function onDown(e, initialY) {
-        e.preventDefault();
-        startY = initialY;
+      function startDrag(clientY) {
+        startY = clientY;
         start = current;
-        sheet.style.transition = 'none';
         dragging = true;
-        window.addEventListener(moveEvent, onMove, { passive: false });
-        window.addEventListener(endEvent, onUp);
+        sheet.style.transition = 'none';
+        window.addEventListener('pointermove', onMove, { passive: false });
+        window.addEventListener('pointerup', onUp);
       }
 
       function onMove(e) {
         if (!dragging) return;
         e.preventDefault();
-        const dy = getY(e) - startY;
+        const dy = e.clientY - startY;
         current = clamp(start + dy, 0, collapsed);
         sheet.style.transform = `translateY(${current}px)`;
       }
@@ -505,40 +497,47 @@
         }
         sheet.style.transform = `translateY(${current}px)`;
         dragging = false;
-        window.removeEventListener(moveEvent, onMove);
-        window.removeEventListener(endEvent, onUp);
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
       }
 
-      sheet.addEventListener(startEvent, e => {
+      sheet.addEventListener('pointerdown', e => {
         if (sheet.classList.contains('open')) {
-          const startClientY = getY(e);
-          const maybeDrag = moveEvt => {
-            const dy = getY(moveEvt) - startClientY;
-            if (dy > 0 && content.scrollTop === 0) {
-              moveEvt.preventDefault();
+          const initialY = e.clientY;
+          const detectDrag = moveEvt => {
+            const dy = moveEvt.clientY - initialY;
+            if (dy > 5 && content.scrollTop === 0) {
               disableScroll();
-              onDown(moveEvt, startClientY);
-              content.removeEventListener(moveEvent, maybeDrag);
+              startDrag(initialY);
+              sheet.removeEventListener('pointermove', detectDrag);
             } else if (Math.abs(dy) > 5) {
-              content.removeEventListener(moveEvent, maybeDrag);
+              sheet.removeEventListener('pointermove', detectDrag);
             }
           };
-          content.addEventListener(moveEvent, maybeDrag, { passive: false });
-          content.addEventListener(
-            endEvent,
-            () => content.removeEventListener(moveEvent, maybeDrag),
-            { once: true }
-          );
+          const stopDetect = () =>
+            sheet.removeEventListener('pointermove', detectDrag);
+          sheet.addEventListener('pointermove', detectDrag, { passive: false });
+          sheet.addEventListener('pointerup', stopDetect, { once: true });
         } else {
           disableScroll();
-          onDown(e, getY(e));
+          startDrag(e.clientY);
         }
       });
 
-      handle.addEventListener(startEvent, e => {
+      handle.addEventListener('click', e => {
         e.stopPropagation();
-        disableScroll();
-        onDown(e, getY(e));
+        if (dragging) return;
+        if (sheet.classList.contains('open')) {
+          current = collapsed;
+          sheet.classList.remove('open');
+          sheet.style.transform = `translateY(${current}px)`;
+          disableScroll();
+        } else {
+          current = 0;
+          sheet.classList.add('open');
+          sheet.style.transform = `translateY(${current}px)`;
+          enableScroll();
+        }
       });
 
       sheet.addEventListener('click', () => {
@@ -548,19 +547,6 @@
           sheet.classList.add('open');
           sheet.style.transform = `translateY(${current}px)`;
           enableScroll();
-        }
-      });
-
-      handle.addEventListener('click', e => {
-        e.stopPropagation();
-        if (dragging) return;
-        current = current === 0 ? collapsed : 0;
-        sheet.classList.toggle('open');
-        sheet.style.transform = `translateY(${current}px)`;
-        if (current === 0) {
-          enableScroll();
-        } else {
-          disableScroll();
         }
       });
     }


### PR DESCRIPTION
## Summary
- let users close the equipment bottom sheet by dragging anywhere on it while keeping inner scrolling

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68916f04f5f08322a9e346eba4d35bbe