### PR TITLE
feat: make equipment summary menu responsive

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,17 +9,21 @@
 </head>
 <body class="p-4">
   <div class="container">
-    <div class="d-flex justify-content-between mb-3">
-      <h1>Résumé des équipements</h1>
-      <div>
-        {% if current_user.is_admin %}
-        <a href="{{ url_for('admin') }}" class="btn btn-sm btn-secondary">Admin</a>
-        <a href="{{ url_for('users') }}" class="btn btn-sm btn-secondary ms-2">Utilisateurs</a>
-        {% endif %}
-        <a href="{{ url_for('logout') }}" 
-           class="btn btn-sm btn-outline-secondary">Déconnexion</a>
+    <nav class="navbar navbar-expand-md navbar-light mb-3 px-0">
+      <h1 class="navbar-brand fs-4 mb-0">Résumé des équipements</h1>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Basculer la navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse justify-content-end" id="navbar-menu">
+        <ul class="navbar-nav mb-2 mb-md-0">
+          {% if current_user.is_admin %}
+          <li class="nav-item"><a href="{{ url_for('admin') }}" class="nav-link">Admin</a></li>
+          <li class="nav-item"><a href="{{ url_for('users') }}" class="nav-link">Utilisateurs</a></li>
+          {% endif %}
+          <li class="nav-item"><a href="{{ url_for('logout') }}" class="nav-link">Déconnexion</a></li>
+        </ul>
       </div>
-    </div>
+    </nav>
 
     {% if message %}
     <div class="alert alert-info">{{ message }}</div>
@@ -66,4 +70,5 @@
     </div>
   </div>
 </body>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </html>

--- a/tests/test_activity_score.py
+++ b/tests/test_activity_score.py
@@ -91,3 +91,15 @@ def test_index_sorted_by_score(monkeypatch):
     html = resp.data.decode()
     assert "🥇" in html
     assert html.index("T1") < html.index("T2")
+
+
+def test_index_has_mobile_menu():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "navbar-toggler" in html
+    assert 'id="navbar-menu"' in html


### PR DESCRIPTION
## Summary
- use Bootstrap navbar for equipment summary menu with mobile-friendly toggler
- test for responsive menu presence

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68916f341fe483229d68d10434ae5e1a