### PR TITLE
Enable swipe-down closing for equipment sheet on mobile

### DIFF
--- a/static/js/equipment-sheet.js
+++ b/static/js/equipment-sheet.js
@@ -46,6 +46,9 @@
       lastTime = e.timeStamp;
       dragging = false;
       sheet.style.transition = 'none';
+      if (startScrollTop === 0) {
+        e.preventDefault();
+      }
     }
 
     function onPointerMove(e) {

--- a/static/js/equipment-sheet.js
+++ b/static/js/equipment-sheet.js
@@ -61,7 +61,11 @@
 
       if (!dragging) {
         if (maybeDrag) {
-          if (Math.abs(dx) > Math.abs(dy) || dy <= 0) {
+          if (
+            Math.abs(dx) > Math.abs(dy) ||
+            (start === 0 && dy <= 0) ||
+            (start > 0 && dy >= 0)
+          ) {
             maybeDrag = false;
             enableScroll();
             sheet.releasePointerCapture(e.pointerId);
@@ -102,7 +106,8 @@
           enableScroll();
         }
       } else {
-        if (current < collapsed / 2) {
+        const traveled = start - current;
+        if (traveled > 120 || velocity < -0.25) {
           current = 0;
           sheet.classList.add('open');
           enableScroll();
@@ -115,6 +120,7 @@
       sheet.style.transform = `translateY(${current}px)`;
       dragging = false;
       maybeDrag = false;
+      sheet.releasePointerCapture(e.pointerId);
     }
 
     sheet.addEventListener('pointerdown', onPointerDown, { passive: false });

--- a/static/js/equipment-sheet.js
+++ b/static/js/equipment-sheet.js
@@ -1,0 +1,140 @@
+(function() {
+  function setupEquipmentSheet() {
+    const sheet = document.getElementById('equipment-sheet');
+    if (!sheet) return;
+    const handle = sheet.querySelector('.drag-handle');
+    const content = document.getElementById('equipment-sheet-content');
+    if (!handle || !content) return;
+
+    const handleStyles = getComputedStyle(handle);
+    const handleHeight =
+      handle.offsetHeight +
+      parseFloat(handleStyles.marginTop) +
+      parseFloat(handleStyles.marginBottom);
+    const collapsed = sheet.offsetHeight - handleHeight;
+    let current = collapsed;
+    sheet.style.transform = `translateY(${current}px)`;
+    const clamp = (v, min, max) => Math.min(Math.max(v, min), max);
+
+    const disableScroll = () => {
+      content.style.touchAction = 'none';
+      content.style.overflowY = 'hidden';
+    };
+    const enableScroll = () => {
+      content.style.touchAction = 'pan-y';
+      content.style.overflowY = 'auto';
+    };
+    disableScroll();
+
+    let startY = 0;
+    let startX = 0;
+    let start = 0;
+    let startScrollTop = 0;
+    let lastY = 0;
+    let lastTime = 0;
+    let dragging = false;
+    const mediaQuery = window.matchMedia('(max-width: 768px)');
+
+    function onPointerDown(e) {
+      if (!mediaQuery.matches || !e.isPrimary) return;
+      sheet.setPointerCapture(e.pointerId);
+      startY = e.clientY;
+      startX = e.clientX;
+      start = current;
+      startScrollTop = content.scrollTop;
+      lastY = e.clientY;
+      lastTime = e.timeStamp;
+      dragging = false;
+      sheet.style.transition = 'none';
+    }
+
+    function onPointerMove(e) {
+      if (!mediaQuery.matches || !e.isPrimary) return;
+      const dy = e.clientY - startY;
+      const dx = e.clientX - startX;
+
+      if (!dragging) {
+        if (Math.abs(dx) > Math.abs(dy)) return;
+        if (start === 0) {
+          if (startScrollTop === 0 && dy > 0) {
+            dragging = true;
+          } else {
+            return;
+          }
+        } else {
+          dragging = true;
+          disableScroll();
+        }
+      }
+      if (!dragging) return;
+      e.preventDefault();
+      current = clamp(start + dy, 0, collapsed);
+      sheet.style.transform = `translateY(${current}px)`;
+      lastY = e.clientY;
+      lastTime = e.timeStamp;
+    }
+
+    function onPointerUp(e) {
+      if (!dragging) return;
+      const dt = e.timeStamp - lastTime;
+      const velocity = dt > 0 ? (e.clientY - lastY) / dt : 0;
+      sheet.style.transition = '';
+      if (start === 0) {
+        if (current > 120 || velocity > 0.25) {
+          current = collapsed;
+          sheet.classList.remove('open');
+          disableScroll();
+        } else {
+          current = 0;
+          sheet.classList.add('open');
+          enableScroll();
+        }
+      } else {
+        if (current < collapsed / 2) {
+          current = 0;
+          sheet.classList.add('open');
+          enableScroll();
+        } else {
+          current = collapsed;
+          sheet.classList.remove('open');
+          disableScroll();
+        }
+      }
+      sheet.style.transform = `translateY(${current}px)`;
+      dragging = false;
+    }
+
+    sheet.addEventListener('pointerdown', onPointerDown, { passive: false });
+    sheet.addEventListener('pointermove', onPointerMove, { passive: false });
+    sheet.addEventListener('pointerup', onPointerUp, { passive: false });
+    sheet.addEventListener('pointercancel', onPointerUp, { passive: false });
+
+    handle.addEventListener('click', e => {
+      e.stopPropagation();
+      if (dragging) return;
+      if (current === 0) {
+        current = collapsed;
+        sheet.classList.remove('open');
+        sheet.style.transform = `translateY(${current}px)`;
+        disableScroll();
+      } else {
+        current = 0;
+        sheet.classList.add('open');
+        sheet.style.transform = `translateY(${current}px)`;
+        enableScroll();
+      }
+    });
+
+    sheet.addEventListener('click', () => {
+      if (dragging) return;
+      if (!sheet.classList.contains('open')) {
+        current = 0;
+        sheet.classList.add('open');
+        sheet.style.transform = `translateY(${current}px)`;
+        enableScroll();
+      }
+    });
+  }
+
+  window.setupEquipmentSheet = setupEquipmentSheet;
+})();

--- a/static/js/equipment-sheet.js
+++ b/static/js/equipment-sheet.js
@@ -34,7 +34,6 @@
     let lastTime = 0;
     let dragging = false;
     let maybeDrag = false;
-    let captureEl = null;
     const mediaQuery = window.matchMedia('(max-width: 768px)');
 
     function onPointerDown(e) {
@@ -49,14 +48,7 @@
       maybeDrag = startScrollTop <= 0;
       sheet.style.transition = 'none';
       if (maybeDrag) {
-        captureEl = e.target;
-        try {
-          captureEl.setPointerCapture(e.pointerId);
-        } catch (err) {
-          captureEl = sheet;
-          captureEl.setPointerCapture(e.pointerId);
-        }
-        disableScroll();
+        sheet.setPointerCapture(e.pointerId);
         e.preventDefault();
       }
     }
@@ -74,14 +66,11 @@
             (start > 0 && dy >= 0)
           ) {
             maybeDrag = false;
-            enableScroll();
-            if (captureEl) {
-              try { captureEl.releasePointerCapture(e.pointerId); } catch (err) {}
-              captureEl = null;
-            }
+            sheet.releasePointerCapture(e.pointerId);
             return;
           }
           dragging = true;
+          disableScroll();
         } else {
           return;
         }
@@ -96,11 +85,7 @@
     function onPointerUp(e) {
       if (!dragging) {
         if (maybeDrag) {
-          enableScroll();
-          if (captureEl) {
-            try { captureEl.releasePointerCapture(e.pointerId); } catch (err) {}
-            captureEl = null;
-          }
+          sheet.releasePointerCapture(e.pointerId);
           maybeDrag = false;
         }
         return;
@@ -133,10 +118,7 @@
       sheet.style.transform = `translateY(${current}px)`;
       dragging = false;
       maybeDrag = false;
-      if (captureEl) {
-        try { captureEl.releasePointerCapture(e.pointerId); } catch (err) {}
-        captureEl = null;
-      }
+      sheet.releasePointerCapture(e.pointerId);
     }
 
     sheet.addEventListener('pointerdown', onPointerDown, { passive: false });

--- a/static/js/equipment-sheet.js
+++ b/static/js/equipment-sheet.js
@@ -58,6 +58,7 @@
         if (start === 0) {
           if (startScrollTop === 0 && dy > 0) {
             dragging = true;
+            disableScroll();
           } else {
             return;
           }

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -30,7 +30,7 @@
       display: flex;
       flex-direction: column;
       overflow: hidden;
-      touch-action: none;
+      touch-action: pan-y;
     }
     .bottom-sheet.open {
       transform: translateY(0);
@@ -49,6 +49,9 @@
       overflow-y: auto;
     }
     @media (max-width: 768px) {
+      html, body {
+        overscroll-behavior: none;
+      }
       #equipment-sheet-content {
         touch-action: pan-y;
         overscroll-behavior-y: contain;

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -47,8 +47,13 @@
     .bottom-sheet .sheet-content {
       flex: 1;
       overflow-y: auto;
-      overscroll-behavior: contain;
-      touch-action: pan-y;
+    }
+    @media (max-width: 768px) {
+      #equipment-sheet-content {
+        touch-action: pan-y;
+        overscroll-behavior-y: contain;
+        -webkit-overflow-scrolling: touch;
+      }
     }
   </style>
 </head>
@@ -60,9 +65,9 @@
   </div>
 
   {% if zones %}
-  <div id="info-sheet" class="bottom-sheet">
+  <div id="equipment-sheet" class="bottom-sheet">
     <div class="drag-handle"></div>
-    <div class="sheet-content p-3">
+    <div id="equipment-sheet-content" class="sheet-content p-3">
       <h5 class="mb-3">{{ equipment.name }}</h5>
       <div id="date-nav" class="input-group mb-3">
         <button id="prev-day" class="btn btn-outline-secondary" {% if not prev_day_url %}disabled{% endif %} data-url="{{ prev_day_url or '' }}">&lt;</button>
@@ -119,6 +124,7 @@
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="{{ url_for('static', filename='js/equipment-sheet.js') }}"></script>
   <script>
     let map;
     let zoneLayer;
@@ -437,112 +443,10 @@
       });
     }
 
-    function setupBottomSheet() {
-      const sheet = document.getElementById('info-sheet');
-      if (!sheet) return;
-      const handle = sheet.querySelector('.drag-handle');
-      const content = sheet.querySelector('.sheet-content');
-      const handleStyles = getComputedStyle(handle);
-      const handleHeight =
-        handle.offsetHeight +
-        parseFloat(handleStyles.marginTop) +
-        parseFloat(handleStyles.marginBottom);
-      const collapsed = sheet.offsetHeight - handleHeight;
-      let current = collapsed;
-      sheet.style.transform = `translateY(${current}px)`;
-      const clamp = (v, min, max) => Math.min(Math.max(v, min), max);
-
-      const disableScroll = () => {
-        content.style.touchAction = 'none';
-        content.style.overflowY = 'hidden';
-      };
-      const enableScroll = () => {
-        content.style.touchAction = 'pan-y';
-        content.style.overflowY = 'auto';
-      };
-      disableScroll();
-
-      let startY = 0;
-      let start = 0;
-      let dragging = false;
-
-      function onDown(e) {
-        e.preventDefault();
-        startY = e.clientY;
-        start = current;
-        sheet.style.transition = 'none';
-        dragging = true;
-        window.addEventListener('pointermove', onMove);
-        window.addEventListener('pointerup', onUp);
-      }
-
-      function onMove(e) {
-        if (!dragging) return;
-        e.preventDefault();
-        const dy = e.clientY - startY;
-        current = clamp(start + dy, 0, collapsed);
-        sheet.style.transform = `translateY(${current}px)`;
-      }
-
-      function onUp(e) {
-        if (!dragging) return;
-        sheet.style.transition = '';
-        if (current < collapsed / 2) {
-          current = 0;
-          sheet.classList.add('open');
-          enableScroll();
-        } else {
-          current = collapsed;
-          sheet.classList.remove('open');
-          disableScroll();
-        }
-        sheet.style.transform = `translateY(${current}px)`;
-        dragging = false;
-        window.removeEventListener('pointermove', onMove);
-        window.removeEventListener('pointerup', onUp);
-      }
-
-      sheet.addEventListener('pointerdown', e => {
-        if (!sheet.classList.contains('open')) {
-          disableScroll();
-          onDown(e);
-        }
-      });
-
-      handle.addEventListener('pointerdown', e => {
-        e.stopPropagation();
-        disableScroll();
-        onDown(e);
-      });
-
-      sheet.addEventListener('click', () => {
-        if (dragging) return;
-        if (!sheet.classList.contains('open')) {
-          current = 0;
-          sheet.classList.add('open');
-          sheet.style.transform = `translateY(${current}px)`;
-          enableScroll();
-        }
-      });
-
-      handle.addEventListener('click', e => {
-        e.stopPropagation();
-        if (dragging) return;
-        current = current === 0 ? collapsed : 0;
-        sheet.classList.toggle('open');
-        sheet.style.transform = `translateY(${current}px)`;
-        if (current === 0) {
-          enableScroll();
-        } else {
-          disableScroll();
-        }
-      });
-    }
-
     window.addEventListener('DOMContentLoaded', () => {
       setupPeriodSelectors();
       setupInteractions();
-      setupBottomSheet();
+      setupEquipmentSheet();
     });
   </script>
 </body>

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -395,6 +395,7 @@ def test_bottom_sheet_uses_inner_scroll_container():
     handle_pos = html.find('class="drag-handle"')
     content_pos = html.find('class="sheet-content')
     assert handle_pos != -1 and content_pos != -1 and handle_pos < content_pos
+    assert "overscroll-behavior: none" in html
     assert "overscroll-behavior-y: contain" in html
     assert "touch-action: pan-y" in html
 
@@ -414,6 +415,8 @@ def test_bottom_sheet_disables_content_scroll_during_drag():
     assert "content.style.touchAction = 'none'" in js
     assert "content.style.touchAction = 'pan-y'" in js
     assert "if (!sheet.classList.contains('open'))" in js
+    assert js.count('e.preventDefault()') >= 2
+    assert "if (startScrollTop === 0)" in js
 
 
 def test_row_click_uses_instant_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -416,7 +416,7 @@ def test_bottom_sheet_disables_content_scroll_during_drag():
     assert "content.style.touchAction = 'pan-y'" in js
     assert "if (!sheet.classList.contains('open'))" in js
     assert js.count('e.preventDefault()') >= 2
-    assert "if (startScrollTop === 0)" in js
+    assert "startScrollTop === 0" in js
 
 
 def test_row_click_uses_instant_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import re
+from pathlib import Path
 from datetime import date, timedelta, datetime
 
 from pytest import approx
@@ -394,7 +395,7 @@ def test_bottom_sheet_uses_inner_scroll_container():
     handle_pos = html.find('class="drag-handle"')
     content_pos = html.find('class="sheet-content')
     assert handle_pos != -1 and content_pos != -1 and handle_pos < content_pos
-    assert "overscroll-behavior: contain" in html
+    assert "overscroll-behavior-y: contain" in html
     assert "touch-action: pan-y" in html
 
 
@@ -407,9 +408,12 @@ def test_bottom_sheet_disables_content_scroll_during_drag():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "content.style.touchAction = 'none'" in html
-    assert "content.style.touchAction = 'pan-y'" in html
-    assert "if (!sheet.classList.contains('open'))" in html
+    assert "js/equipment-sheet.js" in html
+    js_path = Path(ROOT_DIR) / "static/js/equipment-sheet.js"
+    js = js_path.read_text()
+    assert "content.style.touchAction = 'none'" in js
+    assert "content.style.touchAction = 'pan-y'" in js
+    assert "if (!sheet.classList.contains('open'))" in js
 
 
 def test_row_click_uses_instant_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -417,6 +417,8 @@ def test_bottom_sheet_disables_content_scroll_during_drag():
     assert "if (!sheet.classList.contains('open'))" in js
     assert js.count('e.preventDefault()') >= 2
     assert "startScrollTop === 0" in js
+    assert "start === 0 && dy <= 0" in js
+    assert "start > 0 && dy >= 0" in js
 
 
 def test_row_click_uses_instant_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -416,7 +416,8 @@ def test_bottom_sheet_disables_content_scroll_during_drag():
     assert "content.style.touchAction = 'pan-y'" in js
     assert "if (!sheet.classList.contains('open'))" in js
     assert js.count('e.preventDefault()') >= 2
-    assert "startScrollTop === 0" in js
+    assert "startScrollTop <= 0" in js
+    assert ".setPointerCapture(e.pointerId)" in js
     assert "start === 0 && dy <= 0" in js
     assert "start > 0 && dy >= 0" in js
 


### PR DESCRIPTION
## Summary
- allow bottom sheet content to be identified via new IDs and mobile scrolling rules
- add mobile-only JS module to swipe-close the equipment sheet with pointer events
- adjust tests for external equipment sheet script

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6891fca3a4d8832295b9177750fb07f1