### PR TITLE
Improve equipment bottom sheet mobile interactions

### DIFF
--- a/static/js/equipment-sheet.js
+++ b/static/js/equipment-sheet.js
@@ -17,8 +17,8 @@
 
   function computeMaxOffset() {
     const handleHeight = handle.offsetHeight || 0;
-    // leave the drag handle visible when the sheet is closed
-    maxOffset = sheet.offsetHeight - handleHeight - 8;
+    const peek = 40; // keep part of the sheet visible when closed
+    maxOffset = sheet.offsetHeight - handleHeight - 8 - peek;
   }
 
   function applyOffset(y) {
@@ -44,6 +44,7 @@
     ) {
       return; // allow normal scrolling
     }
+    e.preventDefault();
     dragging = true;
     startY = e.clientY;
     startX = e.clientX;
@@ -104,7 +105,7 @@
     if (initialized) return;
     computeMaxOffset();
     snap(false);
-    sheet.addEventListener('pointerdown', onPointerDown, { passive: true });
+    sheet.addEventListener('pointerdown', onPointerDown, { passive: false });
     sheet.addEventListener('pointermove', onPointerMove, { passive: false });
     sheet.addEventListener('pointerup', onPointerUp, { passive: true });
     sheet.addEventListener('pointercancel', onPointerUp, { passive: true });

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -9,7 +9,11 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css"/>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
   <style>
-    html, body { height: 100%; margin: 0; }
+    html, body {
+      height: 100%;
+      margin: 0;
+      overscroll-behavior-y: none;
+    }
     #map-container { height: 100%; }
     .zone-row { cursor: pointer; }
     .legend { background: white; padding: 6px 8px; line-height: 18px; color: #555; }


### PR DESCRIPTION
## Summary
- Prevent pull-to-refresh by disabling overscroll and default touch behavior during drags
- Keep a larger portion of the equipment sheet visible when closed for easier access

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68926352ecb483229edc87f07cb65527