### PR TITLE
feat: add responsive navbar to summary page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,24 +7,31 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  
 </head>
-<body class="p-4">
-  <div class="container">
-    <div class="d-flex justify-content-between mb-3 align-items-center">
-      <div class="d-flex align-items-center">
+<body>
+  <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand d-flex align-items-center" href="#">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
-        <h1 class="mb-0">Résumé des équipements</h1>
-      </div>
-      <div>
-        {% if current_user.is_admin %}
-        <a href="{{ url_for('admin') }}" class="btn btn-sm btn-secondary">Admin</a>
-        <a href="{{ url_for('users') }}" class="btn btn-sm btn-secondary ms-2">Utilisateurs</a>
-        {% endif %}
-        <a href="{{ url_for('logout') }}" 
-           class="btn btn-sm btn-outline-secondary">Déconnexion</a>
+        <span>Résumé des équipements</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          {% if current_user.is_admin %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('admin') }}">Admin</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('users') }}">Utilisateurs</a></li>
+          {% endif %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Déconnexion</a></li>
+        </ul>
       </div>
     </div>
+  </nav>
 
+  <div class="container">
     {% if message %}
     <div class="alert alert-info">{{ message }}</div>
     {% endif %}
@@ -69,5 +76,6 @@
       </table>
     </div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/tests/test_responsive_navbar.py
+++ b/tests/test_responsive_navbar.py
@@ -1,0 +1,46 @@
+from app import create_app  # noqa: E402
+from models import db, User, Equipment, Config
+
+
+def make_app():
+    app = create_app()
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", is_admin=True)
+        admin.set_password("pass")
+        db.session.add(admin)
+        db.session.add(
+            Config(
+                traccar_url="http://example.com",
+                traccar_token="dummy",
+            )
+        )
+        db.session.add(Equipment(id_traccar=1, name="tractor"))
+        db.session.commit()
+    return app
+
+
+def login(client):
+    return client.post(
+        "/login", data={"username": "admin", "password": "pass"}
+    )
+
+
+def test_index_navbar_responsive():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    toggler = soup.select_one("button.navbar-toggler")
+    assert toggler is not None
+    assert toggler.get("data-bs-target") == "#navbarNav"
+    nav_container = soup.select_one("div#navbarNav")
+    assert nav_container is not None
+    assert "navbar-collapse" in nav_container.get("class", [])


### PR DESCRIPTION
## Summary
- replace equipment summary header with responsive Bootstrap navbar
- load Bootstrap JavaScript bundle for navbar toggling
- add regression test covering responsive navigation

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68926b3155ec8322a21909c13c2de0c6