### PR TITLE
feat: replace map legend with popup

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -285,19 +285,37 @@
       trackLayer = L.geoJSON(null, {
         style: { color: 'blue' }
       }).addTo(map);
-      const legend = L.control({ position: 'topright' });
-      legend.onAdd = () => {
-        const div = L.DomUtil.create('div', 'legend');
+      const legendHtml = (() => {
         const levels = [1, 2, 3, 4, 5];
         let html = '<strong>Passages</strong><br>';
         levels.forEach((l, i) => {
           const label = i === levels.length - 1 ? `${l}+` : `${l}`;
           html += `<i style="background:${colors[i]}"></i> ${label}<br>`;
         });
-        div.innerHTML = html;
+        return html;
+      })();
+      const legendBtn = L.control({ position: 'topright' });
+      legendBtn.onAdd = () => {
+        const div = L.DomUtil.create('div', 'legend-btn-container leaflet-bar');
+        const button = L.DomUtil.create('button', 'btn btn-light rounded-circle', div);
+        button.id = 'legend-btn';
+        button.type = 'button';
+        button.title = 'Légende';
+        button.style.width = '32px';
+        button.style.height = '32px';
+        button.style.lineHeight = '30px';
+        button.style.padding = '0';
+        button.innerHTML = '?';
+        L.DomEvent.disableClickPropagation(button);
+        L.DomEvent.on(button, 'click', () => {
+          L.popup()
+            .setLatLng(map.getCenter())
+            .setContent(`<div class="legend">${legendHtml}</div>`)
+            .openOn(map);
+        });
         return div;
       };
-      legend.addTo(map);
+      legendBtn.addTo(map);
       map.on('moveend zoomend', () => { if (!skipFetch) fetchData(); });
       if (initialBounds) {
         const b = L.latLngBounds(

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -292,7 +292,7 @@ def test_tracks_endpoint_triggers_analysis(monkeypatch):
     assert len(data["features"]) == 1
 
 
-def test_equipment_page_shows_legend():
+def test_equipment_page_has_help_button_and_no_legend():
     app = make_app()
     client = app.test_client()
     login(client)
@@ -301,7 +301,9 @@ def test_equipment_page_shows_legend():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "const legend = L.control({ position: 'topright' });" in html
+    assert "const legend = L.control" not in html
+    assert "button.id = 'legend-btn'" in html
+    assert "button.innerHTML = '?'" in html
 
 
 def test_zones_geojson_endpoint():


### PR DESCRIPTION
## Summary
- replace Leaflet legend control with "?" help button in equipment map
- show legend in popup when button clicked
- add regression test for legend button and removal of persistent legend

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6892ad1b13f88322a5ae6efc88e5394b