### PR TITLE
Logo cliquable sur la page équipement

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -55,10 +55,10 @@
 </head>
 <body class="m-0">
   <div id="map-container"></div>
-  <div class="position-absolute top-0 start-0 p-2 d-flex align-items-center bg-white rounded shadow" style="z-index:1100;">
-    <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
-    <a href="{{ url_for('index') }}" class="btn btn-sm btn-light">Retour</a>
-    <a href="{{ url_for('logout') }}" class="btn btn-sm btn-light ms-2">Déconnexion</a>
+  <div class="position-absolute top-0 start-0 p-2 bg-white rounded shadow" style="z-index:1100;">
+    <a href="{{ url_for('index') }}">
+      <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40">
+    </a>
   </div>
 
   {% if zones %}

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -136,6 +136,31 @@ def get_js_array(html: str, var_name: str):
     return json.loads(match.group(1))
 
 
+def test_header_has_clickable_logo_and_no_buttons():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    from flask import url_for
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    with app.test_request_context():
+        index_url = url_for("index")
+
+    html = resp.data.decode()
+    assert "Retour" not in html
+    assert "Déconnexion" not in html
+
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    logo_link = soup.find("a", href=index_url)
+    assert logo_link is not None
+    assert logo_link.find("img", alt="Trackteur Analyse") is not None
+
+
 def test_equipment_detail_page_loads():
     app = make_app()
     client = app.test_client()


### PR DESCRIPTION
## Résumé
- Supprime les liens "Retour" et "Déconnexion" de la page équipement
- Ajoute un lien sur le logo redirigeant vers la page d'accueil
- Ajout d'un test vérifiant l'absence des anciens boutons et la présence du logo cliquable

## Tests
- `flake8 .`
- `mypy .`
- `pytest --cov=. >/tmp/pytest.log && tail -n 2 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6892ad2585408322b272cd932df25816