### PR TITLE
Limit equipment calendar to available dates

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -51,6 +51,9 @@
     .flatpickr-calendar {
       z-index: 2000;
     }
+    .flatpickr-day.no-data {
+      opacity: 0.3;
+    }
   </style>
 </head>
 <body class="m-0">
@@ -352,6 +355,13 @@
           dateFormat: 'Y-m-d',
           allowInput: false,
           defaultDate: dateInput.value ? dateInput.value.split(' to ') : null,
+          enable: availableDates,
+          onDayCreate: function(dObj, dStr, fp, dayElem) {
+            const date = dayElem.dateObj.toISOString().slice(0, 10);
+            if (!availableDates.includes(date)) {
+              dayElem.classList.add('no-data');
+            }
+          },
           onChange: function(selectedDates, dateStr) {
             if (selectedDates.length === 2 || selectedDates.length === 0) {
               dateInput.value = dateStr;

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -195,6 +195,9 @@ def test_day_menu_excludes_days_without_zones():
     html = resp.data.decode()
     dates = get_js_array(html, "availableDates")
     assert nz.isoformat() not in dates
+    assert "enable: availableDates" in html
+    assert "onDayCreate" in html
+    assert ".flatpickr-day.no-data" in html
 
 
 def test_equipment_page_has_day_navigation():


### PR DESCRIPTION
## Summary
- Restrict flatpickr calendar to selectable dates with data
- Highlight days without data and mark as unselectable
- Test that available dates are passed to the template and calendar restricts start/end selection

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6892aee112408322ad3bc5755c569da5