### PR TITLE
Use url_for for logo link in navbar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 <body>
   <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
     <div class="container-fluid">
-      <a class="navbar-brand d-flex align-items-center" href="#">
+      <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
         <span>Résumé des équipements</span>
       </a>


### PR DESCRIPTION
## Summary
- Fix navbar brand link to route to home using `url_for('index')`

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6892c7a0578883229df72e6d8297c5b4