### PR TITLE
Rendre les contrôles de carte transparents

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -9,3 +9,9 @@
     transform: translateY(calc(100% - 3rem));
   }
 }
+
+.leaflet-control-zoom,
+#legend-btn {
+  background: transparent;
+  border: none;
+}

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -299,7 +299,7 @@
       })();
       const legendBtn = L.control({ position: 'topright' });
       legendBtn.onAdd = () => {
-        const div = L.DomUtil.create('div', 'legend-btn-container leaflet-bar');
+        const div = L.DomUtil.create('div', 'legend-btn-container');
         const button = L.DomUtil.create('button', 'btn btn-light rounded-circle', div);
         button.id = 'legend-btn';
         button.type = 'button';


### PR DESCRIPTION
## Summary
- retire la classe `leaflet-bar` du bouton d'aide dans la page équipement
- supprime l'arrière-plan des contrôles de zoom et du bouton de légende

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`
- tentative de capture d'écran via `puppeteer` échouée (libasound.so.2 manquant)


------
https://chatgpt.com/codex/tasks/task_e_6892c78f39c4832284dcb03fd2da5fdb