### PR TITLE
Refactor equipment page styles into external CSS

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,3 +1,76 @@
+html,
+body {
+  height: 100%;
+  margin: 0;
+  overscroll-behavior-y: none;
+}
+
+#map-container {
+  height: 100%;
+}
+
+.zone-row {
+  cursor: pointer;
+}
+
+.legend {
+  background: white;
+  padding: 6px 8px;
+  line-height: 18px;
+  color: #555;
+}
+
+.legend i {
+  width: 18px;
+  height: 18px;
+  float: left;
+  margin-right: 8px;
+  opacity: 0.7;
+}
+
+#date-nav button {
+  min-width: 3rem;
+}
+
+.bottom-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 50vh;
+  background: #fff;
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.bottom-sheet .drag-handle {
+  width: 50px;
+  height: 5px;
+  background: #999;
+  border-radius: 3px;
+  margin: 8px auto;
+  cursor: grab;
+  touch-action: none;
+}
+
+.bottom-sheet .sheet-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.flatpickr-calendar {
+  z-index: 2000;
+}
+
+.flatpickr-day.no-data {
+  opacity: 0.3;
+}
+
 @media (max-width: 768px) {
   [data-sheet="equipment"] {
     overscroll-behavior-y: contain;

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -9,52 +9,6 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"/>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css"/>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
-  <style>
-    html, body {
-      height: 100%;
-      margin: 0;
-      overscroll-behavior-y: none;
-    }
-    #map-container { height: 100%; }
-    .zone-row { cursor: pointer; }
-    .legend { background: white; padding: 6px 8px; line-height: 18px; color: #555; }
-    .legend i { width: 18px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; }
-    #date-nav button { min-width: 3rem; }
-    .bottom-sheet {
-      position: fixed;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      height: 50vh;
-      background: #fff;
-      border-top-left-radius: 1rem;
-      border-top-right-radius: 1rem;
-      box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
-      z-index: 1000;
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-    }
-    .bottom-sheet .drag-handle {
-      width: 50px;
-      height: 5px;
-      background: #999;
-      border-radius: 3px;
-      margin: 8px auto;
-      cursor: grab;
-      touch-action: none;
-    }
-    .bottom-sheet .sheet-content {
-      flex: 1;
-      overflow-y: auto;
-    }
-    .flatpickr-calendar {
-      z-index: 2000;
-    }
-    .flatpickr-day.no-data {
-      opacity: 0.3;
-    }
-  </style>
 </head>
 <body class="m-0">
   <div id="map-container"></div>

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -3,6 +3,7 @@ import sys
 import json
 import re
 from datetime import date, timedelta, datetime
+from pathlib import Path
 
 from pytest import approx
 
@@ -221,7 +222,9 @@ def test_day_menu_excludes_days_without_zones():
     dates = get_js_array(html, "availableDates")
     assert nz.isoformat() not in dates
     assert "onDayCreate" in html
-    assert ".flatpickr-day.no-data" in html
+    assert "css/app.css" in html
+    css = (Path(app.static_folder) / "css" / "app.css").read_text()
+    assert ".flatpickr-day.no-data" in css
     assert "flatpickr-disabled" in html
     assert "!availableDates.includes(start)" in html
     assert "!availableDates.includes(end)" in html


### PR DESCRIPTION
## Summary
- move inline styles from equipment template into `static/css/app.css`
- ensure equipment template links to external stylesheet and update tests

## Testing
- `flake8 .`
- `mypy .`
- `pytest tests/test_equipment_page.py::test_equipment_detail_page_loads -q`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6892c7a725708322978f96c57c2cccd7