### PR TITLE
Remove equipment summary text and fix mobile navbar layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,10 +11,9 @@
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
-    <div class="container-fluid">
+    <div class="container-fluid flex-nowrap">
       <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
-        <span>Résumé des équipements</span>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
## Summary
- remove "Résumé des équipements" text from index navbar
- prevent navbar wrapping so hamburger menu stays on first line on mobile

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6892cc4d8afc832295e99ecada4bb9e7