### PR TITLE
fix: center login card on mobile

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -7,8 +7,8 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
-<body class="p-4">
-  <section class="d-flex flex-column justify-content-center align-items-center min-vh-100">
+<body>
+  <section class="d-flex flex-column justify-content-center align-items-center min-vh-100 p-4">
     <div class="card p-4 shadow w-100" style="max-width: 400px;">
       <div class="text-center mb-4">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="180">


### PR DESCRIPTION
## Summary
- ensure login card is vertically centered on mobile by moving page padding from the body to the section container

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6892cc835df88322af65cfec4de8e2b1