### PR TITLE
Open sheet when clicking zone row

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -419,6 +419,7 @@
         row.addEventListener('click', () => {
           const zoneId = parseInt(row.dataset.zoneId);
           highlightRows([zoneId]);
+          if (window.openEquipmentSheet) window.openEquipmentSheet();
           const layer = featureLayers[zoneId];
           if (layer) {
             highlightZone(zoneId);

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -426,6 +426,18 @@ def test_equipment_sheet_has_data_attributes_and_script():
     assert 'equipment-sheet.js' in html
 
 
+def test_row_click_opens_sheet():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "openEquipmentSheet()" in html
+
+
 def test_row_click_uses_instant_zoom():
     app = make_app()
     client = app.test_client()


### PR DESCRIPTION
## Summary
- open the bottom sheet when clicking on a zone row in the equipment page
- cover the new behavior with a test ensuring `openEquipmentSheet()` is present

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6892ccc712808322833b9654aa3f92f7