### PR TITLE
Open sheet when clicking zone row

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -153,6 +153,7 @@
     function highlightZone(ids, skipZoom = false) {
       zoneLayer.eachLayer(l => l.setStyle({ weight: 1 }));
       ids = Array.isArray(ids) ? ids : [ids];
+      if (window.openEquipmentSheet) window.openEquipmentSheet();
       let bounds;
       ids.forEach(id => {
         const layer = featureLayers[id];
@@ -419,7 +420,6 @@
         row.addEventListener('click', () => {
           const zoneId = parseInt(row.dataset.zoneId);
           highlightRows([zoneId]);
-          if (window.openEquipmentSheet) window.openEquipmentSheet();
           const layer = featureLayers[zoneId];
           if (layer) {
             highlightZone(zoneId);

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -419,6 +419,7 @@
         row.addEventListener('click', () => {
           const zoneId = parseInt(row.dataset.zoneId);
           highlightRows([zoneId]);
+          if (window.openEquipmentSheet) window.openEquipmentSheet();
           const layer = featureLayers[zoneId];
           if (layer) {
             highlightZone(zoneId);

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -419,6 +419,7 @@
       document.querySelectorAll('.zone-row').forEach(row => {
         row.addEventListener('click', () => {
           const zoneId = parseInt(row.dataset.zoneId);
+          if (window.openEquipmentSheet) window.openEquipmentSheet();
           highlightRows([zoneId]);
           const layer = featureLayers[zoneId];
           if (layer) {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -172,9 +172,7 @@
         const finish = () => {
           skipFetch = false;
           fetchData().then(() => {
-            if (ids.length === 1 && featureLayers[ids[0]]) {
-              featureLayers[ids[0]].openPopup();
-            }
+            highlightZone(ids, true);
           });
         };
         const ensureZoom = () => {

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -426,7 +426,7 @@ def test_equipment_sheet_has_data_attributes_and_script():
     assert 'equipment-sheet.js' in html
 
 
-def test_row_click_opens_sheet():
+def test_highlight_zone_opens_sheet():
     app = make_app()
     client = app.test_client()
     login(client)
@@ -437,6 +437,21 @@ def test_row_click_opens_sheet():
     html = resp.data.decode()
     start = html.find("function highlightZone")
     end = html.find("function fetchData", start)
+    snippet = html[start:end]
+    assert "openEquipmentSheet()" in snippet
+
+
+def test_row_click_opens_sheet():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    start = html.find("row.addEventListener('click'")
+    end = html.find("highlightZone(zoneId", start)
     snippet = html[start:end]
     assert "openEquipmentSheet()" in snippet
 

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -509,6 +509,25 @@ def test_highlight_zone_skip_zoom_parameter():
     assert "highlightZone(zoneId, true)" in html
 
 
+def test_highlight_zone_reapplies_after_fetch():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    start = html.find("function highlightZone")
+    end = html.find("function fetchData()", start)
+    snippet = html[start:end]
+
+    pattern = re.compile(
+        r"fetchData\(\)\.then\(\(\) => \{\s*highlightZone\(ids, true\);"
+    )
+    assert pattern.search(snippet)
+
+
 def test_bounds_check_before_zooming():
     app = make_app()
     client = app.test_client()

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -435,7 +435,10 @@ def test_row_click_opens_sheet():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "openEquipmentSheet()" in html
+    start = html.find("function highlightZone")
+    end = html.find("function fetchData", start)
+    snippet = html[start:end]
+    assert "openEquipmentSheet()" in snippet
 
 
 def test_row_click_uses_instant_zoom():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -426,6 +426,18 @@ def test_equipment_sheet_has_data_attributes_and_script():
     assert 'equipment-sheet.js' in html
 
 
+def test_row_click_opens_sheet():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "openEquipmentSheet()" in html
+
+
 def test_row_click_uses_instant_zoom():
     app = make_app()
     client = app.test_client()


### PR DESCRIPTION
## Summary
- open the bottom sheet when clicking on a zone row in the equipment page
- cover the new behavior with a test ensuring `openEquipmentSheet()` is present

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6892ccc712808322833b9654aa3f92f7