### PR TITLE
Improve equipment legend button and placement

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -10,8 +10,20 @@
   }
 }
 
-.leaflet-control-zoom,
-#legend-btn {
+.leaflet-control-zoom {
   background: transparent;
   border: none;
+}
+
+#legend-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #6c757d;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  padding: 0;
 }

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -19,6 +19,7 @@
     .zone-row { cursor: pointer; }
     .legend { background: white; padding: 6px 8px; line-height: 18px; color: #555; }
     .legend i { width: 18px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; }
+    .legend-popup { position: absolute; top: 60px; right: 10px; z-index: 1100; }
     #date-nav button { min-width: 3rem; }
     .bottom-sheet {
       position: fixed;
@@ -63,6 +64,8 @@
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40">
     </a>
   </div>
+
+  <div id="legend-popup" class="legend-popup d-none"></div>
 
   {% if zones %}
   <div id="info-sheet" class="bottom-sheet" data-sheet="equipment" data-open="false">
@@ -297,28 +300,26 @@
         });
         return html;
       })();
+      const legendPopup = document.getElementById('legend-popup');
+      if (legendPopup) {
+        legendPopup.innerHTML = `<div class="legend">${legendHtml}</div>`;
+      }
       const legendBtn = L.control({ position: 'topright' });
       legendBtn.onAdd = () => {
         const div = L.DomUtil.create('div', 'legend-btn-container');
-        const button = L.DomUtil.create('button', 'btn btn-light rounded-circle', div);
+        const button = L.DomUtil.create('button', '', div);
         button.id = 'legend-btn';
         button.type = 'button';
         button.title = 'Légende';
-        button.style.width = '32px';
-        button.style.height = '32px';
-        button.style.lineHeight = '30px';
-        button.style.padding = '0';
         button.innerHTML = '?';
         L.DomEvent.disableClickPropagation(button);
         L.DomEvent.on(button, 'click', () => {
-          L.popup()
-            .setLatLng(map.getCenter())
-            .setContent(`<div class="legend">${legendHtml}</div>`)
-            .openOn(map);
+          if (legendPopup) legendPopup.classList.toggle('d-none');
         });
         return div;
       };
       legendBtn.addTo(map);
+      map.on('click', () => { if (legendPopup) legendPopup.classList.add('d-none'); });
       map.on('moveend zoomend', () => { if (!skipFetch) fetchData(); });
       if (initialBounds) {
         const b = L.latLngBounds(

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -334,6 +334,7 @@ def test_equipment_page_has_help_button_and_no_legend():
     assert "const legend = L.control" not in html
     assert "button.id = 'legend-btn'" in html
     assert "button.innerHTML = '?'" in html
+    assert 'id="legend-popup"' in html
 
 
 def test_zones_geojson_endpoint():


### PR DESCRIPTION
## Summary
- restyle help `?` button as a grey circle and show legend in a fixed panel
- add test ensuring legend panel is present on equipment page

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6892cd0ae5248322bc676aa707f1168f