### PR TITLE
Center zones when info sheet is open

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -184,7 +184,13 @@
       if (bounds) {
         skipFetch = true;
         return new Promise(resolve => {
+          const sheet = document.querySelector('[data-sheet="equipment"]');
+          const isOpen = sheet && sheet.getAttribute('data-open') === 'true';
+          const offset = isOpen ? sheet.getBoundingClientRect().height / 2 : 0;
           const finish = () => {
+            if (offset) {
+              map.panBy([0, -offset], { animate: false });
+            }
             skipFetch = false;
             fetchData().then(() => {
               if (showPopup && ids.length === 1 && featureLayers[ids[0]]) {
@@ -452,8 +458,8 @@
           if (!zonesLoaded) {
             await fetchData();
           }
-          await selectZone(zoneId);
           openEquipmentSheet();
+          await selectZone(zoneId);
         });
       });
       setupMap();

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -492,9 +492,9 @@ def test_row_click_calls_highlight_zone_with_popup():
     assert "openEquipmentSheet()" in snippet
     assert "if (!zonesLoaded)" in snippet
     fd = snippet.index("await fetchData()")
-    sz = snippet.index("await selectZone(zoneId)")
     os = snippet.index("openEquipmentSheet()")
-    assert fd < sz < os
+    sz = snippet.index("await selectZone(zoneId)")
+    assert fd < os < sz
     assert "parseInt" not in snippet
 
 
@@ -513,6 +513,23 @@ def test_select_zone_calls_highlight_and_popup():
     assert "highlightRows([zoneId])" in snippet
     assert "return highlightZone(zoneId, true)" in snippet
     assert "parseInt" not in snippet
+
+
+def test_highlight_zone_offsets_for_open_sheet():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    start = html.find("function highlightZone")
+    end = html.find("function selectZone")
+    snippet = html[start:end] if end != -1 else html[start:]
+    assert "[data-sheet=\"equipment\"]" in snippet
+    assert "getAttribute('data-open') === 'true'" in snippet
+    assert "map.panBy([" in snippet
 
 
 def test_rebuild_date_layers_uses_properties_id():


### PR DESCRIPTION
## Summary
- offset map centering when info sheet is open so selected zones stay visible
- open info sheet before centering selected zone
- test that highlightZone compensates for open sheet

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6893cf3251e883228a9c196c91958823