### PR TITLE
Center zones when info sheet is open

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -184,7 +184,13 @@
       if (bounds) {
         skipFetch = true;
         return new Promise(resolve => {
+          const sheet = document.querySelector('[data-sheet="equipment"]');
+          const isOpen = sheet && sheet.getAttribute('data-open') === 'true';
+          const offset = isOpen ? sheet.getBoundingClientRect().height / 2 : 0;
           const finish = () => {
+            if (offset) {
+              map.panBy([0, -offset], { animate: false });
+            }
             skipFetch = false;
             fetchData().then(() => {
               if (showPopup && ids.length === 1 && featureLayers[ids[0]]) {
@@ -452,8 +458,8 @@
           if (!zonesLoaded) {
             await fetchData();
           }
-          await selectZone(zoneId);
           openEquipmentSheet();
+          await selectZone(zoneId);
         });
       });
       setupMap();

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -127,6 +127,7 @@
     let skipFetch = false;
     let fetchToken = 0;
     let zonesLoaded = false;
+    let autoZoomed = false;
     const equipmentId = {{ equipment.id }};
     const initialBounds = {{ bounds|tojson }};
     const colors = ['#2b83ba', '#abdda4', '#ffffbf', '#fdae61', '#d7191c'];
@@ -199,21 +200,19 @@
               resolve();
             });
           };
-          const ensureZoom = () => {
-            map.zoomOut(3, { animate: false });
+          const applyZoom = () => {
+            if (!autoZoomed) {
+              map.zoomOut(3, { animate: false });
+              autoZoomed = true;
+            }
             finish();
           };
           const center = bounds.getCenter();
-          if (map.getBounds().contains(bounds)) {
-            if (map.getCenter().equals(center)) {
-              ensureZoom();
-            } else {
-              map.once('moveend', ensureZoom);
-              map.panTo(center, { animate: false });
-            }
+          if (map.getCenter().equals(center)) {
+            applyZoom();
           } else {
-            map.once('moveend', ensureZoom);
-            map.fitBounds(bounds, { animate: false });
+            map.once('moveend', applyZoom);
+            map.panTo(center, { animate: false });
           }
         });
       }

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -200,12 +200,8 @@
             });
           };
           const ensureZoom = () => {
-            if (map.getZoom() < 17) {
-              map.once('zoomend', finish);
-              map.setZoom(17, { animate: false });
-            } else {
-              finish();
-            }
+            map.zoomOut(3, { animate: false });
+            finish();
           };
           const center = bounds.getCenter();
           if (map.getBounds().contains(bounds)) {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -189,7 +189,7 @@
           const offset = isOpen ? sheet.getBoundingClientRect().height / 2 : 0;
           const finish = () => {
             if (offset) {
-              map.panBy([0, -offset], { animate: false });
+              map.panBy([0, offset], { animate: false });
             }
             skipFetch = false;
             fetchData().then(() => {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -127,7 +127,6 @@
     let skipFetch = false;
     let fetchToken = 0;
     let zonesLoaded = false;
-    let autoZoomed = false;
     const equipmentId = {{ equipment.id }};
     const initialBounds = {{ bounds|tojson }};
     const colors = ['#2b83ba', '#abdda4', '#ffffbf', '#fdae61', '#d7191c'];
@@ -187,10 +186,10 @@
         return new Promise(resolve => {
           const sheet = document.querySelector('[data-sheet="equipment"]');
           const isOpen = sheet && sheet.getAttribute('data-open') === 'true';
-          const offset = isOpen ? sheet.getBoundingClientRect().height / 2 : 0;
+          const offset = isOpen ? sheet.getBoundingClientRect().height : 0;
           const finish = () => {
             if (offset) {
-              map.panBy([0, offset], { animate: false });
+              map.panBy([0, offset / 2], { animate: false });
             }
             skipFetch = false;
             fetchData().then(() => {
@@ -200,20 +199,12 @@
               resolve();
             });
           };
-          const applyZoom = () => {
-            if (!autoZoomed) {
-              map.zoomOut(3, { animate: false });
-              autoZoomed = true;
-            }
-            finish();
-          };
-          const center = bounds.getCenter();
-          if (map.getCenter().equals(center)) {
-            applyZoom();
-          } else {
-            map.once('moveend', applyZoom);
-            map.panTo(center, { animate: false });
-          }
+          map.once('moveend', finish);
+          map.fitBounds(bounds, {
+            paddingTopLeft: [0, 0],
+            paddingBottomRight: [0, offset],
+            animate: false,
+          });
         });
       }
       if (showPopup && ids.length === 1 && featureLayers[ids[0]]) {

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -435,7 +435,7 @@ def test_equipment_sheet_has_data_attributes_and_script():
     assert 'equipment-sheet.js' in html
 
 
-def test_row_click_uses_instant_zoom():
+def test_row_click_fits_bounds_without_zoom_out():
     app = make_app()
     client = app.test_client()
     login(client)
@@ -444,14 +444,15 @@ def test_row_click_uses_instant_zoom():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
+    assert "map.fitBounds(bounds" in html
     assert "animate: false" in html
-    assert "panTo(center, { animate: false" in html
-    assert "if (!autoZoomed)" in html
-    assert "zoomOut(3, { animate: false" in html
+    assert "zoomOut" not in html
+    assert "autoZoomed" not in html
+    assert "panTo(center" not in html
     assert "fetchData().then" in html
 
 
-def test_row_click_recenters_when_visible():
+def test_row_click_calls_fit_bounds():
     app = make_app()
     client = app.test_client()
     login(client)
@@ -460,10 +461,10 @@ def test_row_click_recenters_when_visible():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "panTo(center, { animate: false" in html
+    assert "map.fitBounds(bounds" in html
 
 
-def test_row_click_zoom_out_three_levels():
+def test_row_click_does_not_zoom_out():
     app = make_app()
     client = app.test_client()
     login(client)
@@ -472,9 +473,8 @@ def test_row_click_zoom_out_three_levels():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "if (!autoZoomed)" in html
-    assert "autoZoomed = true" in html
-    assert "zoomOut(3" in html
+    assert "zoomOut" not in html
+    assert "autoZoomed" not in html
 
 
 def test_row_click_calls_highlight_zone_with_popup():
@@ -531,7 +531,8 @@ def test_highlight_zone_offsets_for_open_sheet():
     snippet = html[start:end] if end != -1 else html[start:]
     assert "[data-sheet=\"equipment\"]" in snippet
     assert "getAttribute('data-open') === 'true'" in snippet
-    assert "map.panBy([0, offset" in snippet
+    assert "paddingBottomRight: [0, offset]" in snippet
+    assert "map.panBy([0, offset / 2" in snippet
     assert "map.panBy([0, -offset" not in snippet
 
 

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -529,7 +529,8 @@ def test_highlight_zone_offsets_for_open_sheet():
     snippet = html[start:end] if end != -1 else html[start:]
     assert "[data-sheet=\"equipment\"]" in snippet
     assert "getAttribute('data-open') === 'true'" in snippet
-    assert "map.panBy([" in snippet
+    assert "map.panBy([0, offset" in snippet
+    assert "map.panBy([0, -offset" not in snippet
 
 
 def test_rebuild_date_layers_uses_properties_id():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -492,9 +492,9 @@ def test_row_click_calls_highlight_zone_with_popup():
     assert "openEquipmentSheet()" in snippet
     assert "if (!zonesLoaded)" in snippet
     fd = snippet.index("await fetchData()")
-    sz = snippet.index("await selectZone(zoneId)")
     os = snippet.index("openEquipmentSheet()")
-    assert fd < sz < os
+    sz = snippet.index("await selectZone(zoneId)")
+    assert fd < os < sz
     assert "parseInt" not in snippet
 
 
@@ -513,6 +513,23 @@ def test_select_zone_calls_highlight_and_popup():
     assert "highlightRows([zoneId])" in snippet
     assert "return highlightZone(zoneId, true)" in snippet
     assert "parseInt" not in snippet
+
+
+def test_highlight_zone_offsets_for_open_sheet():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    start = html.find("function highlightZone")
+    end = html.find("function selectZone")
+    snippet = html[start:end] if end != -1 else html[start:]
+    assert "[data-sheet=\"equipment\"]" in snippet
+    assert "getAttribute('data-open') === 'true'" in snippet
+    assert "map.panBy([" in snippet
 
 
 def test_rebuild_date_layers_uses_properties_id():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -445,8 +445,8 @@ def test_row_click_uses_instant_zoom():
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "animate: false" in html
-    assert "fitBounds(bounds, { animate: false" in html
-    assert "once('moveend', ensureZoom" in html
+    assert "panTo(center, { animate: false" in html
+    assert "if (!autoZoomed)" in html
     assert "zoomOut(3, { animate: false" in html
     assert "fetchData().then" in html
 
@@ -472,6 +472,8 @@ def test_row_click_zoom_out_three_levels():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
+    assert "if (!autoZoomed)" in html
+    assert "autoZoomed = true" in html
     assert "zoomOut(3" in html
 
 
@@ -578,7 +580,7 @@ def test_bounds_check_before_zooming():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "getBounds().contains" in html
+    assert "getBounds().contains" not in html
 
 
 def test_zone_rows_have_ids():

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -447,7 +447,7 @@ def test_row_click_uses_instant_zoom():
     assert "animate: false" in html
     assert "fitBounds(bounds, { animate: false" in html
     assert "once('moveend', ensureZoom" in html
-    assert "once('zoomend', finish" in html
+    assert "zoomOut(3, { animate: false" in html
     assert "fetchData().then" in html
 
 
@@ -463,7 +463,7 @@ def test_row_click_recenters_when_visible():
     assert "panTo(center, { animate: false" in html
 
 
-def test_row_click_enforces_min_zoom():
+def test_row_click_zoom_out_three_levels():
     app = make_app()
     client = app.test_client()
     login(client)
@@ -472,7 +472,7 @@ def test_row_click_enforces_min_zoom():
         eq = Equipment.query.first()
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
-    assert "setZoom(17" in html
+    assert "zoomOut(3" in html
 
 
 def test_row_click_calls_highlight_zone_with_popup():


### PR DESCRIPTION
## Summary
- offset map centering when info sheet is open so selected zones stay visible
- open info sheet before centering selected zone
- test that highlightZone compensates for open sheet

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6893cf3251e883228a9c196c91958823