### PR TITLE
Allow selecting same start and end date

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -390,6 +390,7 @@
       }
 
       let picker;
+      let firstDate = null;
       if (dateInput) {
         picker = flatpickr(dateInput, {
           mode: 'range',
@@ -404,9 +405,17 @@
               dayElem.addEventListener('click', e => e.preventDefault());
             }
           },
-          onChange: function(selectedDates, dateStr) {
-            if (selectedDates.length === 2) {
+          onChange: function(selectedDates, dateStr, instance) {
+            if (selectedDates.length === 1) {
+              const current = selectedDates[0];
+              if (firstDate && firstDate.getTime() === current.getTime()) {
+                instance.setDate([current, current], true);
+              } else {
+                firstDate = current;
+              }
+            } else if (selectedDates.length === 2) {
               const [start, end] = selectedDates.map(d => d.toISOString().slice(0, 10));
+              firstDate = null;
               if (!availableDates.includes(start) || !availableDates.includes(end)) {
                 this.clear();
                 return;
@@ -414,6 +423,7 @@
               dateInput.value = dateStr;
               updatePeriod(dateStr);
             } else if (selectedDates.length === 0) {
+              firstDate = null;
               dateInput.value = '';
             }
           }

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -1086,3 +1086,17 @@ def test_map_click_does_not_open_sheet():
 
     html = resp.data.decode()
     assert html.count("openEquipmentSheet()") == 1
+
+
+def test_calendar_allows_single_day_selection():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+
+    html = resp.data.decode()
+    assert "firstDate = null" in html
+    assert "instance.setDate([current, current], true)" in html


### PR DESCRIPTION
## Summary
- allow selecting a single day in the equipment calendar by clicking the day twice
- add regression test ensuring calendar script handles single day selection

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6893ea3d1af08322a88e88867344383b