### PR TITLE
Fix zone grouping and pass count in equipment detail

### DIFF
--- a/app.py
+++ b/app.py
@@ -523,7 +523,7 @@ def create_app():
                 (
                     i
                     for i, full in enumerate(agg_all)
-                    if set(z.get("ids", [])) <= set(full.get("ids", []))
+                    if set(z.get("ids", [])) == set(full.get("ids", []))
                 ),
                 None,
             )
@@ -541,7 +541,7 @@ def create_app():
                 {
                     "id": idx,
                     "dates": ", ".join(sorted(set(info["dates"]))),
-                    "pass_count": len(info["dates"]),
+                    "pass_count": len(set(info["dates"])),
                     "surface_ha": info["surface"],
                 }
             )


### PR DESCRIPTION
## Summary
- Group aggregated zones using strict ID equality and count unique dates when computing pass counts
- Update existing tests for unique-date pass counts and add regression test for partially overlapping zones across days

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_689402d9d75483229b7567d5dc531942