### PR TITLE
Run reanalysis in background

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -91,12 +91,30 @@
       <button type="submit" class="btn btn-primary">Enregistrer la configuration</button>
       <button type="submit" formaction="{{ url_for('reanalyze_all') }}" class="btn btn-danger ms-2">Tout réanalyser</button>
     </form>
+    <div id="analysis-status" class="mt-3"></div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     [...tooltipTriggerList].forEach(el => new bootstrap.Tooltip(el));
+
+    function checkStatus() {
+      fetch("{{ url_for('analysis_status') }}")
+        .then(resp => resp.json())
+        .then(data => {
+          const el = document.getElementById('analysis-status');
+          if (data.running) {
+            el.textContent = `Analyse en cours : ${data.current}/${data.total}`;
+            setTimeout(checkStatus, 2000);
+          } else if (data.total > 0) {
+            el.textContent = `Analyse terminée (${data.total} équipements).`;
+          } else {
+            el.textContent = '';
+          }
+        });
+    }
+    checkStatus();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reprocess equipment in a background thread and expose progress through `/analysis_status`
- poll progress on the admin page to give users feedback during long analyses
- extend tests for async reanalysis and status access

## Testing
- `flake8 .`
- `mypy .`
- `pytest --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68940920906883229bc4c72dca4a1819