### PR TITLE
Améliore la présentation du menu principal

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,13 +7,15 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   
 </head>
 <body>
-  <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
+  <nav class="navbar navbar-expand-md navbar-dark bg-dark mb-4">
     <div class="container-fluid flex-nowrap">
       <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
+        <span class="fw-bold">Trackteur Analyse</span>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -21,10 +23,22 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-auto">
           {% if current_user.is_admin %}
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('admin') }}">Admin</a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('users') }}">Utilisateurs</a></li>
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('admin') }}">
+              <i class="bi bi-speedometer2 me-1"></i> Admin
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('users') }}">
+              <i class="bi bi-people me-1"></i> Utilisateurs
+            </a>
+          </li>
           {% endif %}
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Déconnexion</a></li>
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('logout') }}">
+              <i class="bi bi-box-arrow-right me-1"></i> Déconnexion
+            </a>
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Résumé
- Ajout de Bootstrap Icons et passage de la barre de navigation en thème sombre
- Insertion du nom de l'application et d'icônes pour Admin, Utilisateurs et Déconnexion

## Tests
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_689486f96ab083228eb2639581651135