### PR TITLE
Harmonize top banners

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -40,3 +40,12 @@
   border-radius: 50%;
   padding: 0;
 }
+
+/* Barre supérieure cohérente pour toutes les pages */
+.top-bar {
+  background-color: #f8f9fa;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -7,11 +7,12 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body class="p-4">
   <div class="container">
 
-    <div class="d-flex justify-content-between mb-3 align-items-center">
+    <div class="top-bar justify-content-between mb-4">
       <div class="d-flex align-items-center">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
         <h1 class="h3 mb-0">Configuration des équipements</h1>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -7,21 +7,45 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
-<body class="p-4">
-  <div class="container">
-
-    <div class="top-bar justify-content-between mb-4">
-      <div class="d-flex align-items-center">
+<body>
+  <nav class="navbar navbar-expand-md top-bar mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
-        <h1 class="h3 mb-0">Configuration des équipements</h1>
-      </div>
-      <div>
-        <a href="{{ url_for('index') }}" class="btn btn-sm btn-outline-secondary">Retour</a>
-        <a href="{{ url_for('logout') }}" class="btn btn-sm btn-outline-secondary">Déconnexion</a>
+        <span class="fw-bold">Trackteur Analyse</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
+          {% if current_user.is_admin %}
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('admin') }}">
+              <i class="bi bi-speedometer2 me-1"></i> Admin
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('users') }}">
+              <i class="bi bi-people me-1"></i> Utilisateurs
+            </a>
+          </li>
+          {% endif %}
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('logout') }}">
+              <i class="bi bi-box-arrow-right me-1"></i> Déconnexion
+            </a>
+          </li>
+        </ul>
       </div>
     </div>
+  </nav>
+
+  <div class="container">
+    <h1 class="h3 mb-4">Configuration des équipements</h1>
 
     <div
       id="analysis-banner"
@@ -32,7 +56,7 @@
       {% if message %}{{ message }}{% elif error %}{{ error }}{% endif %}
     </div>
 
-      <form method="post" class="mt-3">
+    <form method="post" class="mt-3">
       <!-- Adresse serveur -->
       <div class="mb-3">
         <label for="base_url" class="form-label fw-bold">Adresse du serveur</label>

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -60,7 +60,7 @@
   </style>
 </head>
 <body class="m-0 d-flex flex-column">
-  <header class="p-2 bg-white shadow d-flex align-items-center gap-2" style="z-index:1100;">
+  <header class="top-bar gap-2" style="z-index:1100;">
     <a href="{{ url_for('index') }}">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40">
     </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,10 +8,11 @@
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
   
 </head>
 <body>
-  <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
+  <nav class="navbar navbar-expand-md top-bar mb-4">
     <div class="container-fluid">
       <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">

--- a/templates/setup_step1.html
+++ b/templates/setup_step1.html
@@ -6,12 +6,13 @@
   <title>Configuration – Admin</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body class="p-4">
   <div class="container">
-    <div class="text-center mb-4">
+    <header class="top-bar justify-content-center mb-4">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="80">
-    </div>
+    </header>
     <h1 class="mb-4">Création de l'administrateur</h1>
     <form method="post">
       <div class="mb-3">

--- a/templates/setup_step2.html
+++ b/templates/setup_step2.html
@@ -6,12 +6,13 @@
   <title>Configuration – Serveur</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body class="p-4">
   <div class="container">
-    <div class="text-center mb-4">
+    <header class="top-bar justify-content-center mb-4">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="80">
-    </div>
+    </header>
     <h1 class="mb-4">Connexion au serveur Traccar</h1>
     <form method="post">
       <div class="mb-3">

--- a/templates/setup_step3.html
+++ b/templates/setup_step3.html
@@ -6,12 +6,13 @@
   <title>Configuration – Équipements</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
   <body class="p-4">
     <div class="container">
-      <div class="text-center mb-4">
+      <header class="top-bar justify-content-center mb-4">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="80">
-      </div>
+      </header>
       <h1 class="mb-4">Sélection des appareils à suivre</h1>
       {% if error %}
       <div class="alert alert-danger">{{ error }}</div>

--- a/templates/setup_step4.html
+++ b/templates/setup_step4.html
@@ -6,12 +6,13 @@
   <title>Configuration terminée</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body class="p-4">
   <div class="container">
-    <div class="text-center mb-4">
+    <header class="top-bar justify-content-center mb-4">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="80">
-    </div>
+    </header>
     <h1 class="mb-4">Analyse initiale terminée</h1>
     <ul>
       {% for name in devices %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -6,10 +6,11 @@
   <title>Gestion des utilisateurs</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body class="p-4">
   <div class="container">
-    <div class="d-flex justify-content-between mb-3 align-items-center">
+    <div class="top-bar justify-content-between mb-4">
       <div class="d-flex align-items-center">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
         <h1 class="h3 mb-0">Utilisateurs</h1>

--- a/templates/users.html
+++ b/templates/users.html
@@ -6,20 +6,45 @@
   <title>Gestion des utilisateurs</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
-<body class="p-4">
-  <div class="container">
-    <div class="top-bar justify-content-between mb-4">
-      <div class="d-flex align-items-center">
+<body>
+  <nav class="navbar navbar-expand-md top-bar mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Trackteur Analyse" height="40" class="me-2">
-        <h1 class="h3 mb-0">Utilisateurs</h1>
-      </div>
-      <div>
-        <a href="{{ url_for('index') }}" class="btn btn-sm btn-outline-secondary">Retour</a>
-        <a href="{{ url_for('logout') }}" class="btn btn-sm btn-outline-secondary">Déconnexion</a>
+        <span class="fw-bold">Trackteur Analyse</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
+          {% if current_user.is_admin %}
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('admin') }}">
+              <i class="bi bi-speedometer2 me-1"></i> Admin
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('users') }}">
+              <i class="bi bi-people me-1"></i> Utilisateurs
+            </a>
+          </li>
+          {% endif %}
+          <li class="nav-item">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('logout') }}">
+              <i class="bi bi-box-arrow-right me-1"></i> Déconnexion
+            </a>
+          </li>
+        </ul>
       </div>
     </div>
+  </nav>
+
+  <div class="container">
+    <h1 class="h3 mb-4">Utilisateurs</h1>
 
     {% if message %}
     <div class="alert alert-info">{{ message }}</div>
@@ -81,5 +106,6 @@
       </table>
     </div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Centralize visual styling with a reusable `.top-bar` CSS class for a uniform banner
- Apply the new top bar and stylesheet across admin, setup, equipment and index templates

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_689498ef097883229968cf3a7174be27