### PR TITLE
feat: add gunicorn production setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Démarrer l'application :
 export SKIP_INITIAL_ANALYSIS=1
 python app.py
 ```
+En production, utilisez [Gunicorn](https://gunicorn.org/) :
+```bash
+gunicorn wsgi:app --bind 0.0.0.0:8000
+```
 Accédez à [http://localhost:5000](http://localhost:5000). La page d'accueil liste les équipements, leur dernière position et les surfaces calculées. Vous pouvez lancer une analyse manuelle ou consulter le détail d'un équipement (zones par jour et carte interactive). Une analyse automatique a lieu chaque nuit à 2 h.
 
 ## Structure du projet

--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ En production, utilisez [Gunicorn](https://gunicorn.org/) :
 ```bash
 gunicorn wsgi:app --bind 0.0.0.0:8000
 ```
+### Service systemd (Ubuntu)
+
+Pour exécuter l'application comme un service systemd :
+
+1. Créez `/etc/systemd/system/trackteur-analyse.service` :
+
+   ```ini
+   [Unit]
+   Description=Trackteur Analyse
+   After=network.target
+
+   [Service]
+   User=trackteur
+   WorkingDirectory=/opt/trackteur-analyse
+   Environment="FLASK_SECRET_KEY=changer"
+   ExecStart=/usr/bin/gunicorn wsgi:app --bind 0.0.0.0:8000
+   Restart=always
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+2. Rechargez systemd et démarrez le service :
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now trackteur-analyse.service
+   ```
 Accédez à [http://localhost:5000](http://localhost:5000). La page d'accueil liste les équipements, leur dernière position et les surfaces calculées. Vous pouvez lancer une analyse manuelle ou consulter le détail d'un équipement (zones par jour et carte interactive). Une analyse automatique a lieu chaque nuit à 2 h.
 
 ## Structure du projet

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pytest-cov
 pytest
 mypy
 beautifulsoup4
+gunicorn

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,3 @@
+from app import create_app
+
+app = create_app()


### PR DESCRIPTION
## Summary
- add Gunicorn as production server
- provide wsgi entrypoint
- document running with Gunicorn

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6894c7969c788322baf1e1a3843a6a1e