### PR TITLE
Enable CSRF protection for form submissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ import threading
 
 import requests
 from flask import Flask, render_template, request, redirect, url_for, jsonify
+from flask_wtf import CSRFProtect
+from flask_wtf.csrf import CSRFError
 from flask_login import (
     LoginManager,
     login_user,
@@ -30,6 +32,7 @@ reanalysis_progress = {
 
 def create_app():
     app = Flask(__name__)
+    CSRFProtect(app)
     reanalysis_progress.update(
         {"running": False, "current": 0, "total": 0, "equipment": ""}
     )
@@ -158,6 +161,10 @@ def create_app():
         if Equipment.query.count() == 0:
             if current_user.is_authenticated or request.endpoint != 'login':
                 return redirect(url_for('setup'))
+
+    @app.errorhandler(CSRFError)
+    def handle_csrf_error(e):
+        return 'CSRF token missing or invalid', 400
 
     @login_manager.user_loader
     def load_user(user_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 Flask-Login
+Flask-WTF
 Flask-SQLAlchemy
 Werkzeug
 APScheduler

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -57,6 +57,7 @@
     </div>
 
     <form method="post" class="mt-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <!-- Adresse serveur -->
       <div class="mb-3">
         <label for="base_url" class="form-label fw-bold">Adresse du serveur</label>

--- a/templates/login.html
+++ b/templates/login.html
@@ -17,6 +17,7 @@
       <div class="alert alert-danger">{{ error }}</div>
       {% endif %}
       <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-3">
           <label for="username" class="form-label">Nom d’utilisateur</label>
           <input type="text" class="form-control" id="username" name="username" required autofocus>

--- a/templates/setup_step1.html
+++ b/templates/setup_step1.html
@@ -15,6 +15,7 @@
     </header>
     <h1 class="mb-4">Création de l'administrateur</h1>
     <form method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <label for="username" class="form-label">Nom d'utilisateur</label>
         <input type="text" class="form-control" id="username" name="username" required autofocus>

--- a/templates/setup_step2.html
+++ b/templates/setup_step2.html
@@ -15,6 +15,7 @@
     </header>
     <h1 class="mb-4">Connexion au serveur Traccar</h1>
     <form method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <label for="base_url" class="form-label">Adresse du serveur</label>
         <input type="text" class="form-control" id="base_url" name="base_url" required>

--- a/templates/setup_step3.html
+++ b/templates/setup_step3.html
@@ -18,6 +18,7 @@
       <div class="alert alert-danger">{{ error }}</div>
       {% endif %}
       <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="mb-3">
           {% for dev in devices %}
           <div class="form-check form-check-inline">

--- a/templates/users.html
+++ b/templates/users.html
@@ -52,6 +52,7 @@
 
     <h5 class="mt-4">Ajouter un utilisateur</h5>
     <form method="post" class="row g-2 mb-4">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="action" value="add">
       <div class="col-auto">
         <input type="text" name="username" class="form-control" placeholder="Nom d'utilisateur" required>
@@ -87,6 +88,7 @@
             <td>{{ 'Admin' if user.is_admin else 'Lecture' }}</td>
             <td>
               <form method="post" class="d-inline">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="action" value="reset">
                 <input type="hidden" name="user_id" value="{{ user.id }}">
                 <input type="password" name="password" class="form-control d-inline w-auto" placeholder="Nouveau mot de passe" required>
@@ -94,6 +96,7 @@
               </form>
               {% if user != current_user %}
               <form method="post" class="d-inline ms-2">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="action" value="delete">
                 <input type="hidden" name="user_id" value="{{ user.id }}">
                 <button type="submit" class="btn btn-sm btn-danger">Supprimer</button>

--- a/tests/test_activity_score.py
+++ b/tests/test_activity_score.py
@@ -12,6 +12,7 @@ os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
 from app import create_app  # noqa: E402
 from models import db, User, Equipment, DailyZone, Config  # noqa: E402
 import zone  # noqa: E402
+from tests.utils import login  # noqa: E402
 
 
 def make_app():
@@ -64,13 +65,6 @@ def make_app():
         ])
         db.session.commit()
     return app
-
-
-def login(client):
-    return client.post(
-        "/login",
-        data={"username": "admin", "password": "pass"},
-    )
 
 
 def test_index_sorted_by_score(monkeypatch):

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from app import create_app  # noqa: E402
+from models import db, User, Config, Equipment  # noqa: E402
+from tests.utils import login  # noqa: E402
+
+
+def make_app():
+    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
+    app = create_app()
+    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", is_admin=True)
+        admin.set_password("pass")
+        db.session.add(admin)
+        db.session.add(
+            Config(traccar_url="http://example.com", traccar_token="tok")
+        )
+        db.session.add(Equipment(id_traccar=1, name="eq"))
+        db.session.commit()
+    return app
+
+
+def test_post_without_csrf_returns_400():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    resp = client.post("/admin", data={"base_url": "http://new.com"})
+    assert resp.status_code == 400

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -18,6 +18,7 @@ from app import create_app  # noqa: E402
 from models import db, User, Equipment, Position, Track  # noqa: E402
 from models import DailyZone, Config  # noqa: E402
 import zone  # noqa: E402
+from tests.utils import login  # noqa: E402
 
 
 def make_app():
@@ -122,13 +123,6 @@ def make_app():
         )
         db.session.commit()
     return app
-
-
-def login(client):
-    return client.post(
-        "/login",
-        data={"username": "admin", "password": "pass"},
-    )
 
 
 def get_js_array(html: str, var_name: str):

--- a/tests/test_responsive_navbar.py
+++ b/tests/test_responsive_navbar.py
@@ -1,5 +1,6 @@
 from app import create_app  # noqa: E402
 from models import db, User, Equipment, Config
+from tests.utils import login
 
 
 def make_app():
@@ -20,12 +21,6 @@ def make_app():
         db.session.add(Equipment(id_traccar=1, name="tractor"))
         db.session.commit()
     return app
-
-
-def login(client):
-    return client.post(
-        "/login", data={"username": "admin", "password": "pass"}
-    )
 
 
 def test_index_navbar_responsive():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+import re
+
+
+def extract_csrf_token(html: str) -> str:
+    match = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    assert match, "CSRF token not found"
+    return match.group(1)
+
+
+def get_csrf(client, url: str) -> str:
+    resp = client.get(url)
+    return extract_csrf_token(resp.get_data(as_text=True))
+
+
+def login(client, username: str = "admin", password: str = "pass"):
+    token = get_csrf(client, "/login")
+    return client.post(
+        "/login",
+        data={"username": username, "password": password, "csrf_token": token},
+    )


### PR DESCRIPTION
## Summary
- Secure the Flask app with CSRFProtect and global error handling
- Inject CSRF tokens into all HTML forms
- Add utility helpers and tests covering CSRF enforcement

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6894f709baa083229e2c9b71aa6bb8ff