### PR TITLE
Add form validations and tests

### DIFF
--- a/templates/users.html
+++ b/templates/users.html
@@ -46,6 +46,9 @@
   <div class="container">
     <h1 class="h3 mb-4">Utilisateurs</h1>
 
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
     {% if message %}
     <div class="alert alert-info">{{ message }}</div>
     {% endif %}

--- a/tests/test_form_validation.py
+++ b/tests/test_form_validation.py
@@ -1,0 +1,86 @@
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
+os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
+
+from app import create_app  # noqa: E402
+from models import db, User, Config, Equipment  # noqa: E402
+import zone  # noqa: E402
+
+
+def make_app():
+    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
+    app = create_app()
+    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(username="admin", is_admin=True)
+        admin.set_password("pass")
+        db.session.add(admin)
+        db.session.add(
+            Config(traccar_url="http://example.com", traccar_token="dummy")
+        )
+        db.session.add(Equipment(id_traccar=1, name="eq"))
+        db.session.commit()
+    return app
+
+
+def login(client):
+    return client.post(
+        "/login", data={"username": "admin", "password": "pass"}
+    )
+
+
+def test_login_rejects_short_username():
+    app = make_app()
+    client = app.test_client()
+    resp = client.post(
+        "/login", data={"username": "ab", "password": "pass"}
+    )
+    assert resp.status_code == 200
+    assert "entre 3 et 80" in resp.get_data(as_text=True)
+
+
+def test_admin_rejects_invalid_url(monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    monkeypatch.setattr(zone, "fetch_devices", lambda: [])
+    resp = client.post(
+        "/admin",
+        data={
+            "base_url": "invalid",
+            "token_global": "tok",
+            "eps_meters": "30",
+            "min_surface": "0.2",
+            "alpha_shape": "0.05",
+        },
+    )
+    assert resp.status_code == 200
+    assert "URL serveur invalide" in resp.get_data(as_text=True)
+
+
+def test_user_add_requires_long_username():
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    resp = client.post(
+        "/users",
+        data={
+            "action": "add",
+            "username": "ab",
+            "password": "secret",
+            "role": "read",
+        },
+    )
+    assert resp.status_code == 200
+    assert "entre 3 et 80" in resp.get_data(as_text=True)
+    with app.app_context():
+        assert User.query.filter_by(username="ab").first() is None

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -47,11 +47,11 @@ def test_non_admin_cannot_access_users():
     app = make_app()
     with app.app_context():
         u = User(username="reader", is_admin=False)
-        u.set_password("pwd")
+        u.set_password("pwd1")
         db.session.add(u)
         db.session.commit()
     client = app.test_client()
-    login(client, "reader", "pwd")
+    login(client, "reader", "pwd1")
     resp = client.get("/users")
     assert resp.status_code == 302
 
@@ -60,11 +60,11 @@ def test_non_admin_cannot_access_admin_page():
     app = make_app()
     with app.app_context():
         u = User(username="reader", is_admin=False)
-        u.set_password("pwd")
+        u.set_password("pwd1")
         db.session.add(u)
         db.session.commit()
     client = app.test_client()
-    login(client, "reader", "pwd")
+    login(client, "reader", "pwd1")
     resp = client.get("/admin")
     assert resp.status_code == 302
 
@@ -96,7 +96,7 @@ def test_password_reset():
     app = make_app()
     with app.app_context():
         u = User(username="temp", is_admin=False)
-        u.set_password("old")
+        u.set_password("old1")
         db.session.add(u)
         db.session.commit()
         uid = u.id
@@ -104,22 +104,22 @@ def test_password_reset():
     login(client)
     client.post(
         "/users",
-        data={"action": "reset", "user_id": str(uid), "password": "new"},
+        data={"action": "reset", "user_id": str(uid), "password": "newpass"},
     )
     with app.app_context():
         user = db.session.get(User, uid)
-        assert user.check_password("new")
+        assert user.check_password("newpass")
 
 
 def test_non_admin_cannot_reanalyze():
     app = make_app()
     with app.app_context():
         u = User(username="reader", is_admin=False)
-        u.set_password("pwd")
+        u.set_password("pwd1")
         db.session.add(u)
         db.session.commit()
     client = app.test_client()
-    login(client, "reader", "pwd")
+    login(client, "reader", "pwd1")
     resp = client.post("/reanalyze_all")
     assert resp.status_code == 302
 
@@ -198,11 +198,11 @@ def test_analysis_status_requires_admin(monkeypatch):
     app = make_app()
     with app.app_context():
         u = User(username="reader", is_admin=False)
-        u.set_password("pwd")
+        u.set_password("pwd1")
         db.session.add(u)
         db.session.commit()
     client = app.test_client()
-    login(client, "reader", "pwd")
+    login(client, "reader", "pwd1")
     resp = client.get("/analysis_status")
     assert resp.status_code == 403
 


### PR DESCRIPTION
## Summary
- Validate credentials on login and show user-friendly errors
- Introduce admin and user management form validation logic
- Add unit tests covering validation failures

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6894f70ada8883228bc17568bf89e150