### PR TITLE
Add control flags for scheduler and initial analysis

### DIFF
--- a/tests/test_activity_score.py
+++ b/tests/test_activity_score.py
@@ -16,9 +16,7 @@ from tests.utils import login  # noqa: E402
 
 
 def make_app():
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -18,9 +18,7 @@ from tests.utils import login, get_csrf  # noqa: E402
 
 
 def make_app():
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()
@@ -97,9 +95,7 @@ def test_upgrade_db_adds_config_columns():
     conn.commit()
     conn.close()
 
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     client = app.test_client()
     client.get("/setup")
     with app.app_context():

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -11,9 +11,7 @@ from tests.utils import login  # noqa: E402
 
 
 def make_app():
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -22,9 +22,7 @@ from tests.utils import login  # noqa: E402
 
 
 def make_app():
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()

--- a/tests/test_responsive_navbar.py
+++ b/tests/test_responsive_navbar.py
@@ -4,7 +4,7 @@ from tests.utils import login
 
 
 def make_app():
-    app = create_app()
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()

--- a/tests/test_scheduler_flags.py
+++ b/tests/test_scheduler_flags.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import threading
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+import app  # noqa: E402
+
+
+def test_no_scheduler_or_initial_analysis(monkeypatch):
+    before = {t.name for t in threading.enumerate() if "APScheduler" in t.name}
+
+    start_called = {"called": False}
+
+    def fake_start(self):
+        start_called["called"] = True
+
+    monkeypatch.setattr(app.BackgroundScheduler, "start", fake_start)
+
+    process_called = {"count": 0}
+
+    def fake_process(*a, **k):
+        process_called["count"] += 1
+
+    monkeypatch.setattr(app.zone, "process_equipment", fake_process)
+
+    app.create_app(start_scheduler=False, run_initial_analysis=False)
+
+    after = {t.name for t in threading.enumerate() if "APScheduler" in t.name}
+
+    assert start_called["called"] is False
+    assert process_called["count"] == 0
+    assert after == before

--- a/tests/test_setup_init.py
+++ b/tests/test_setup_init.py
@@ -13,9 +13,7 @@ from models import db, User  # noqa: E402
 
 
 def test_setup_without_db():
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()
@@ -61,9 +59,7 @@ def test_schema_upgrade_adds_pass_count(tmp_path):
             )
         )
 
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_file}"
     client = app.test_client()
     client.get("/setup")
@@ -105,9 +101,7 @@ def test_schema_upgrade_adds_tracks(tmp_path):
             )
         )
 
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_file}"
     client = app.test_client()
     client.get("/setup")
@@ -170,8 +164,7 @@ def test_initial_analysis_upgrades_before_processing(tmp_path, monkeypatch):
         lambda *a, **k: None,
     )
 
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
-    app = importlib.reload(app_module).create_app()
+    app = importlib.reload(app_module).create_app(start_scheduler=False)
 
     with app.app_context():
         from sqlalchemy import inspect

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -16,9 +16,7 @@ os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
 
 
 def make_app():
-    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
-    app = create_app()
-    os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+    app = create_app(start_scheduler=False, run_initial_analysis=False)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     with app.app_context():
         db.drop_all()


### PR DESCRIPTION
## Summary
- allow toggling scheduler and initial_analysis in `create_app`
- disable scheduler/initial analysis in tests and add coverage for the flags

## Testing
- `flake8 app.py tests/test_activity_score.py tests/test_admin_config.py tests/test_csrf.py tests/test_equipment_page.py tests/test_initial_analysis_skip.py tests/test_responsive_navbar.py tests/test_setup_init.py tests/test_users.py tests/test_validations.py tests/test_scheduler_flags.py`
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_6895fd3c58c4832297d6fad7dbec67b6