### PR TITLE
test: centralize app creation via fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+from app import create_app
+from models import db, User, Config, Equipment
+
+
+@pytest.fixture
+def make_app():
+    original = os.environ.get("SKIP_INITIAL_ANALYSIS")
+    os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
+
+    def _make_app():
+        app = create_app(start_scheduler=False, run_initial_analysis=False)
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        with app.app_context():
+            db.drop_all()
+            db.create_all()
+            admin = User(username="admin", is_admin=True)
+            admin.set_password("pass")
+            db.session.add(admin)
+            db.session.add(
+                Config(traccar_url="http://example.com", traccar_token="dummy")
+            )
+            db.session.add(Equipment(id_traccar=1, name="eq"))
+            db.session.commit()
+        return app
+
+    try:
+        yield _make_app
+    finally:
+        if original is None:
+            os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
+        else:
+            os.environ["SKIP_INITIAL_ANALYSIS"] = original
+
+
+@pytest.fixture
+def base_make_app(make_app):
+    return make_app

--- a/tests/test_activity_score.py
+++ b/tests/test_activity_score.py
@@ -9,27 +9,15 @@ if ROOT_DIR not in sys.path:
 os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
 os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
 
-from app import create_app  # noqa: E402
-from models import db, User, Equipment, DailyZone, Config  # noqa: E402
+from models import db, Equipment, DailyZone  # noqa: E402
 import zone  # noqa: E402
 from tests.utils import login  # noqa: E402
 
 
-def make_app():
-    app = create_app(start_scheduler=False, run_initial_analysis=False)
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+def test_index_sorted_by_score(make_app, monkeypatch):
+    app = make_app()
     with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(username="admin", is_admin=True)
-        admin.set_password("pass")
-        db.session.add(admin)
-        db.session.add(
-            Config(
-                traccar_url="http://example.com",
-                traccar_token="dummy",
-            )
-        )
+        db.session.query(Equipment).delete()
         now = datetime.utcnow()
         eq1 = Equipment(
             id_traccar=1,
@@ -62,16 +50,10 @@ def make_app():
             ),
         ])
         db.session.commit()
-    return app
+        ids = {e.name: e.id for e in Equipment.query.all()}
 
-
-def test_index_sorted_by_score(monkeypatch):
-    app = make_app()
     client = app.test_client()
     login(client)
-
-    with app.app_context():
-        ids = {e.name: e.id for e in Equipment.query.all()}
 
     def fake_rel(equipment_id: int) -> float:
         return 9.0 if equipment_id == ids["T1"] else 4.0

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -5,29 +5,10 @@ ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from app import create_app  # noqa: E402
-from models import db, User, Config, Equipment  # noqa: E402
 from tests.utils import login  # noqa: E402
 
 
-def make_app():
-    app = create_app(start_scheduler=False, run_initial_analysis=False)
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(username="admin", is_admin=True)
-        admin.set_password("pass")
-        db.session.add(admin)
-        db.session.add(
-            Config(traccar_url="http://example.com", traccar_token="tok")
-        )
-        db.session.add(Equipment(id_traccar=1, name="eq"))
-        db.session.commit()
-    return app
-
-
-def test_post_without_csrf_returns_400():
+def test_post_without_csrf_returns_400(make_app):
     app = make_app()
     client = app.test_client()
     login(client)

--- a/tests/test_responsive_navbar.py
+++ b/tests/test_responsive_navbar.py
@@ -1,29 +1,7 @@
-from app import create_app  # noqa: E402
-from models import db, User, Equipment, Config
 from tests.utils import login
 
 
-def make_app():
-    app = create_app(start_scheduler=False, run_initial_analysis=False)
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(username="admin", is_admin=True)
-        admin.set_password("pass")
-        db.session.add(admin)
-        db.session.add(
-            Config(
-                traccar_url="http://example.com",
-                traccar_token="dummy",
-            )
-        )
-        db.session.add(Equipment(id_traccar=1, name="tractor"))
-        db.session.commit()
-    return app
-
-
-def test_index_navbar_responsive():
+def test_index_navbar_responsive(make_app):
     app = make_app()
     client = app.test_client()
     login(client)

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -5,30 +5,12 @@ ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from app import create_app  # noqa: E402
-from models import db, User, Config, Equipment  # noqa: E402
+from models import db, User  # noqa: E402
 from tests.utils import login, get_csrf  # noqa: E402
 import zone  # noqa: E402
 
 
-def make_app():
-    app = create_app(start_scheduler=False, run_initial_analysis=False)
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        admin = User(username="admin", is_admin=True)
-        admin.set_password("pass")
-        db.session.add(admin)
-        db.session.add(
-            Config(traccar_url="http://example.com", traccar_token="dummy")
-        )
-        db.session.add(Equipment(id_traccar=1, name="eq"))
-        db.session.commit()
-    return app
-
-
-def test_login_shows_field_errors():
+def test_login_shows_field_errors(make_app):
     app = make_app()
     client = app.test_client()
     token = get_csrf(client, "/login")
@@ -45,7 +27,7 @@ def test_login_shows_field_errors():
     assert "Mot de passe requis" in html
 
 
-def test_admin_invalid_url_validation(monkeypatch):
+def test_admin_invalid_url_validation(make_app, monkeypatch):
     app = make_app()
     client = app.test_client()
     login(client)
@@ -68,7 +50,7 @@ def test_admin_invalid_url_validation(monkeypatch):
     assert "URL invalide" in html
 
 
-def test_users_add_validation_errors():
+def test_users_add_validation_errors(make_app):
     app = make_app()
     client = app.test_client()
     login(client)
@@ -91,7 +73,7 @@ def test_users_add_validation_errors():
     )
 
 
-def test_users_reset_validation_error():
+def test_users_reset_validation_error(make_app):
     app = make_app()
     with app.app_context():
         u = User(username="u1", is_admin=False)


### PR DESCRIPTION
## Summary
- add pytest fixture to build in-memory Flask app with admin, config, and equipment
- refactor tests to use shared `make_app` factory

## Testing
- `flake8 tests/test_activity_score.py tests/test_admin_config.py tests/test_responsive_navbar.py tests/test_csrf.py tests/test_validations.py tests/test_equipment_page.py tests/test_users.py`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6896359149c88322bf6500bec7927570