### PR TITLE
Fallback to historical position when no new data

### DIFF
--- a/zone.py
+++ b/zone.py
@@ -551,6 +551,14 @@ def process_equipment(eq, since=None):
         latest_naive = latest_position_time.replace(tzinfo=None)
         if not eq.last_position or latest_naive > eq.last_position:
             eq.last_position = latest_naive
+    else:
+        latest = (
+            Position.query.filter_by(equipment_id=eq.id)
+            .order_by(Position.timestamp.desc())
+            .first()
+        )
+        if latest:
+            eq.last_position = latest.timestamp
 
     db.session.commit()
 


### PR DESCRIPTION
## Summary
- when `process_equipment` receives no new positions, fallback to the most recent stored `Position` to update `Equipment.last_position`
- add regression test for using historical last position

## Testing
- `flake8 zone.py tests/test_zone.py`
- `mypy zone.py tests/test_zone.py`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68963e7aee6883229ed535cbc685c121