### PR TITLE
Use Google hybrid map for equipment detail

### DIFF
--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -377,8 +377,10 @@
 
     function setupMap() {
       map = L.map('map-container', { zoomControl: false });
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; OpenStreetMap contributors'
+      L.tileLayer('https://{s}.google.com/vt/lyrs=y&x={x}&y={y}&z={z}', {
+        maxZoom: 20,
+        subdomains: ['mt0', 'mt1', 'mt2', 'mt3'],
+        attribution: '&copy; Google'
       }).addTo(map);
       L.control.zoom({ position: 'topright' }).addTo(map);
       L.control.scale().addTo(map);

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -160,6 +160,18 @@ def test_equipment_detail_page_loads(make_app):
     assert html.find('id="map-container"') < html.find('id="zones-table"')
 
 
+def test_equipment_page_uses_google_hybrid(make_app):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        resp = client.get(f"/equipment/{eq.id}")
+    html = resp.data.decode()
+    assert "google.com/vt/lyrs=y" in html
+
+
 def test_equipment_defaults_to_last_day(make_app):
     app = make_app()
     client = app.test_client()


### PR DESCRIPTION
## Summary
- Switch equipment detail map tiles to Google hybrid view
- Test equipment page for Google hybrid tile layer presence

## Testing
- `flake8 .` *(fails: line-too-long, import-order)*
- `mypy .` *(fails: missing requests stubs, Flask attribute)*
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6899d1a3e6448322b8df27f5a22c5924