### PR TITLE
Use Google hybrid map for equipment detail

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -15,31 +15,6 @@
   border: none;
 }
 
-#legend-btn {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #6c757d;
-  color: #fff;
-  border: none;
-  border-radius: 50%;
-  padding: 0;
-}
-
-#filter-btn {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #6c757d;
-  color: #fff;
-  border: none;
-  border-radius: 50%;
-  padding: 0;
-}
 
 /* Barre supérieure cohérente pour toutes les pages */
 .top-bar {
@@ -175,7 +150,8 @@ a:hover { color: var(--primary-600); text-decoration: underline; text-underline-
 
 /* Map UI controls */
 #legend-btn,
-#filter-btn {
+#filter-btn,
+#layer-btn {
   width: 40px;
   height: 40px;
   display: flex;
@@ -190,7 +166,8 @@ a:hover { color: var(--primary-600); text-decoration: underline; text-underline-
   transition: transform 120ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
 #legend-btn:hover,
-#filter-btn:hover { transform: translateY(-1px); background: var(--primary-800); }
+#filter-btn:hover,
+#layer-btn:hover { transform: translateY(-1px); background: var(--primary-800); }
 
 /* Bottom sheet polish */
 .bottom-sheet {

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -144,6 +144,28 @@
     </div>
   </div>
 
+  <div class="modal fade" id="layer-modal" tabindex="-1" aria-labelledby="layerModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="layerModalLabel">Type de carte</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="btn-group" role="group" aria-label="Choisir le fond de carte">
+            <input type="radio" class="btn-check" name="map-type" id="map-hybrid" value="hybrid" autocomplete="off" checked>
+            <label class="btn btn-outline-primary" for="map-hybrid">Hybride</label>
+            <input type="radio" class="btn-check" name="map-type" id="map-roadmap" value="roadmap" autocomplete="off">
+            <label class="btn btn-outline-primary" for="map-roadmap">Plan</label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div id="info-sheet" class="bottom-sheet" data-sheet="equipment" data-open="false">
     <div class="drag-handle"></div>
     <div class="sheet-content p-3" data-sheet-content>
@@ -485,13 +507,32 @@
         button.innerHTML = '<i class="bi bi-layers"></i>';
         L.DomEvent.disableClickPropagation(button);
         L.DomEvent.on(button, 'click', () => {
-          const next = currentBase === baseLayers.hybrid ? 'roadmap' : 'hybrid';
-          map.removeLayer(currentBase);
-          currentBase = baseLayers[next].addTo(map);
+          const modalEl = document.getElementById('layer-modal');
+          if (modalEl) {
+            const modal = new bootstrap.Modal(modalEl);
+            modal.show();
+          }
         });
         return div;
       };
       layerBtn.addTo(map);
+
+      const layerModalEl = document.getElementById('layer-modal');
+      if (layerModalEl) {
+        layerModalEl.addEventListener('show.bs.modal', () => {
+          document.getElementById('map-hybrid').checked = currentBase === baseLayers.hybrid;
+          document.getElementById('map-roadmap').checked = currentBase === baseLayers.roadmap;
+        });
+        document.querySelectorAll('input[name="map-type"]').forEach(radio => {
+          radio.addEventListener('change', e => {
+            const next = e.target.value;
+            if (currentBase !== baseLayers[next]) {
+              map.removeLayer(currentBase);
+              currentBase = baseLayers[next].addTo(map);
+            }
+          });
+        });
+      }
       map.on('moveend zoomend', () => { if (!skipFetch) fetchData(); });
       if (initialBounds) {
         const b = L.latLngBounds(

--- a/tests/test_equipment_page.py
+++ b/tests/test_equipment_page.py
@@ -160,7 +160,7 @@ def test_equipment_detail_page_loads(make_app):
     assert html.find('id="map-container"') < html.find('id="zones-table"')
 
 
-def test_equipment_page_has_layer_button(make_app):
+def test_equipment_page_has_layer_modal(make_app):
     app = make_app()
     client = app.test_client()
     login(client)
@@ -170,6 +170,8 @@ def test_equipment_page_has_layer_button(make_app):
         resp = client.get(f"/equipment/{eq.id}")
     html = resp.data.decode()
     assert "button.id = 'layer-btn'" in html
+    assert 'id="layer-modal"' in html
+    assert 'name="map-type"' in html
     assert "google.com/vt/lyrs=y" in html
     assert "google.com/vt/lyrs=m" in html
 


### PR DESCRIPTION
## Summary
- Switch equipment detail map tiles to Google hybrid view
- Test equipment page for Google hybrid tile layer presence

## Testing
- `flake8 .` *(fails: line-too-long, import-order)*
- `mypy .` *(fails: missing requests stubs, Flask attribute)*
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_6899d1a3e6448322b8df27f5a22c5924