### PR TITLE
Fix equipment analysis inclusion toggle persistence

### DIFF
--- a/app.py
+++ b/app.py
@@ -589,12 +589,10 @@ def create_app(
         if not eq:
             return redirect(url_for('admin', msg='Équipement introuvable'))
         include = request.form.get('include')
-        if include is None:
-            # Fallback: toggle if value not provided
-            eq.include_in_analysis = not bool(getattr(eq, 'include_in_analysis', True))
-        else:
-            # treat '1'/'true' as True, else False
-            eq.include_in_analysis = str(include).lower() in ('1', 'true', 'on', 'yes')
+        # Include in analysis if checkbox present in POST data, otherwise exclude
+        eq.include_in_analysis = str(include).lower() in (
+            '1', 'true', 'on', 'yes'
+        )
         db.session.commit()
         return redirect(url_for('admin', msg='Préférence enregistrée'))
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Admin – Configuration des équipements</title>
+    <title>Admin - Configuration des équipements</title>
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
@@ -272,11 +272,10 @@
             <td>
               <form method="post" action="{{ url_for('toggle_analysis', eq_id=e.id) }}" class="d-inline">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <input type="hidden" name="include" value="{{ 1 if e.include_in_analysis else 0 }}">
                 <div class="form-check form-switch d-inline-flex align-items-center">
-                  <input class="form-check-input" type="checkbox" role="switch"
+                  <input class="form-check-input" type="checkbox" role="switch" name="include"
                          {% if e.include_in_analysis %}checked{% endif %}
-                         onchange="this.previousElementSibling.value=this.checked?1:0; this.form.submit();">
+                         onchange="this.form.submit();">
                 </div>
               </form>
             </td>

--- a/tests/test_toggle_analysis.py
+++ b/tests/test_toggle_analysis.py
@@ -1,0 +1,30 @@
+from models import db, Equipment
+from tests.utils import login, get_csrf
+
+
+def test_toggle_analysis(make_app):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        eq_id = eq.id
+        assert eq.include_in_analysis is True
+
+    token = get_csrf(client, "/admin")
+    # Disable inclusion by not sending the checkbox value
+    client.post(f"/admin/toggle_analysis/{eq_id}", data={"csrf_token": token})
+
+    with app.app_context():
+        assert db.session.get(Equipment, eq_id).include_in_analysis is False
+
+    token = get_csrf(client, "/admin")
+    # Enable inclusion by sending checkbox value
+    client.post(
+        f"/admin/toggle_analysis/{eq_id}",
+        data={"csrf_token": token, "include": "1"},
+    )
+
+    with app.app_context():
+        assert db.session.get(Equipment, eq_id).include_in_analysis is True


### PR DESCRIPTION
## Summary
- simplify admin template toggle to submit checkbox value directly
- handle checkbox in `/admin/toggle_analysis` route
- add regression test for analysis inclusion toggle

## Testing
- `flake8 .` *(fails: many E501 and other existing issues)*
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_689c9202de9c8322840f641c7eea6544