### PR TITLE
Affiche la première position OsmAnd sur la carte

### DIFF
--- a/app.py
+++ b/app.py
@@ -234,7 +234,7 @@ def create_app(
             if not getattr(app, "_db_init", False):
                 db.create_all()
                 upgrade_db()
-                app._db_init = True
+                app._db_init = True  # type: ignore[attr-defined]
 
     @app.before_request
     def ensure_setup():
@@ -1146,8 +1146,24 @@ def create_app(
             else:
                 bounds = tb
 
+        last = (
+            Position.query.filter_by(equipment_id=equipment_id)
+            .order_by(Position.timestamp.desc())
+            .first()
+        )
+        has_last_position = last is not None
+        if bounds is None and last:
+            delta = 0.0005
+            bounds = (
+                last.longitude - delta,
+                last.latitude - delta,
+                last.longitude + delta,
+                last.latitude + delta,
+            )
+
         sorted_dates = sorted(dates)
         available_dates = [d.isoformat() for d in sorted_dates]
+        has_data = bool(zones or has_tracks or has_last_position)
 
         # Add explicit rows for days that have tracks but no computed zones
         # in the selected period (or the auto-selected single day).
@@ -1196,6 +1212,7 @@ def create_app(
             date_value=date_value,
             show_all=show_all,
             has_tracks=has_tracks,
+            has_data=has_data,
         )
 
     @app.route('/equipment/<int:equipment_id>/zones.geojson')

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -109,7 +109,7 @@
   <div class="content-row">
     <div id="map-container" class="flex-fill"></div>
 
-  {% if zones or has_tracks %}
+  {% if has_data %}
   <div class="modal fade" id="legend-modal" tabindex="-1" aria-labelledby="legendModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">

--- a/tests/test_osmand_first_point_bounds.py
+++ b/tests/test_osmand_first_point_bounds.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+import json
+import re
+
+import zone
+from models import db, Equipment, Position, Track, DailyZone
+from tests.utils import login
+
+
+def get_js_array(html: str, var_name: str):
+    match = re.search(rf"const {var_name} = (\[.*?\]);", html)
+    assert match, f"{var_name} not found"
+    return json.loads(match.group(1))
+
+
+def test_initial_bounds_fallback_to_last_position(make_app):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        eq.id_traccar = 0
+        eq.osmand_id = "osm-1"
+        DailyZone.query.delete()
+        Track.query.delete()
+        Position.query.delete()
+        db.session.commit()
+        ts = datetime(2024, 1, 1, 12, 0, 0)
+        db.session.add(
+            Position(
+                equipment_id=eq.id,
+                latitude=45.0,
+                longitude=3.0,
+                timestamp=ts,
+            )
+        )
+        eq.last_position = ts
+        db.session.commit()
+        zone._AGG_CACHE.clear()
+        eq_id = eq.id
+
+    resp = client.get(f"/equipment/{eq_id}")
+    html = resp.data.decode()
+    bounds = get_js_array(html, "initialBounds")
+    assert bounds[0] < 3.0 < bounds[2]
+    assert bounds[1] < 45.0 < bounds[3]
+    assert "Aucune donnée disponible" not in html


### PR DESCRIPTION
## Summary
- évite d'afficher le message "Aucune donnée disponible" lorsqu'une dernière position existe
- utilise un indicateur `has_data` pour afficher la fiche même sans zones ou traces
- teste l'absence du message lorsqu'une seule position OsmAnd est présente

## Testing
- `flake8 .` *(échoue : nombreuses lignes trop longues existantes)*
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_689c92296a888322be542fb9409e7728