### PR TITLE
Icône MDI configurable pour la dernière position

### DIFF
--- a/models.py
+++ b/models.py
@@ -39,6 +39,7 @@ class Equipment(db.Model):  # type: ignore[name-defined]
     osmand_id = db.Column(db.String, unique=True, nullable=True)
     # Whether this equipment is included in zone analysis (True) or only tracked (False)
     include_in_analysis = db.Column(db.Boolean, default=True)
+    marker_icon = db.Column(db.String, nullable=True, default='tractor')
     last_position = db.Column(db.DateTime)
     total_hectares = db.Column(db.Float, default=0.0)
     # Surface unique cumulée (zones dédupliquées entre jours)

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
@@ -255,7 +256,7 @@
           <tr>
             <th>Nom</th>
             <th>Source</th>
-            <th>Inclure dans l'analyse</th>
+            <th>Icône MDI / Analyse</th>
           </tr>
         </thead>
         <tbody>
@@ -270,13 +271,16 @@
               {% endif %}
             </td>
             <td>
-              <form method="post" action="{{ url_for('toggle_analysis', eq_id=e.id) }}" class="d-inline">
+              <form method="post" action="{{ url_for('toggle_analysis', eq_id=e.id) }}" class="d-flex align-items-center gap-2">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="text" class="form-control form-control-sm w-auto" name="icon" value="{{ e.marker_icon or '' }}" placeholder="p. ex. tractor">
                 <div class="form-check form-switch d-inline-flex align-items-center">
-                  <input class="form-check-input" type="checkbox" role="switch" name="include"
+                  <input type="hidden" name="include" value="0">
+                  <input class="form-check-input" type="checkbox" role="switch" name="include" value="1"
                          {% if e.include_in_analysis %}checked{% endif %}
                          onchange="this.form.submit();">
                 </div>
+                <button type="submit" class="btn btn-sm btn-primary">OK</button>
               </form>
             </td>
           </tr>

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css"/>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"/>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css"/>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
@@ -463,16 +464,26 @@
         style: { color: 'blue' }
       }).addTo(map);
       lastLayer = L.geoJSON(null, {
-        pointToLayer: (f, latlng) => L.circleMarker(latlng, {
-          radius: 7,
-          color: f.properties && f.properties.source === 'osmand' ? '#0d6efd' : '#28a745',
-          weight: 2,
-          fillColor: '#fff',
-          fillOpacity: 1.0,
-        }),
+        pointToLayer: (f, latlng) => {
+          const iconName = f.properties && f.properties.icon ? f.properties.icon : 'tractor';
+          const tsStr = f.properties && f.properties.timestamp;
+          let color = '#28a745';
+          if (tsStr) {
+            const ageMs = Date.now() - new Date(tsStr).getTime();
+            if (ageMs > 3600 * 1000) {
+              color = '#6c757d';
+            }
+          } else {
+            color = '#6c757d';
+          }
+          const html = `<i class="mdi mdi-${iconName}" style="font-size:32px;color:${color};"></i>`;
+          return L.marker(latlng, {
+            icon: L.divIcon({ html, className: '', iconSize: [32, 32], iconAnchor: [16, 16] })
+          });
+        },
         onEachFeature: (feature, layer) => {
-          const ts = feature.properties && feature.properties.timestamp || '';
-          const src = feature.properties && feature.properties.source || '';
+          const ts = (feature.properties && feature.properties.timestamp) || '';
+          const src = (feature.properties && feature.properties.source) || '';
           layer.bindPopup(`<b>Dernière position</b><br>${ts}<br>Source: ${src}`);
         }
       }).addTo(map);

--- a/tests/test_last_position_and_source.py
+++ b/tests/test_last_position_and_source.py
@@ -18,6 +18,7 @@ def test_index_source_badge_and_last_geojson(make_app):
         eq = Equipment.query.first()
         eq.id_traccar = eq.id_traccar or 1
         eq.osmand_id = None
+        eq.marker_icon = 'car'
         # Add a last position
         ts = datetime(2023, 1, 1, 15, 0, 0)
         db.session.add(Position(equipment_id=eq.id, latitude=1.0, longitude=2.0, timestamp=ts))
@@ -45,9 +46,11 @@ def test_index_source_badge_and_last_geojson(make_app):
     data = r2.get_json()
     assert data["type"] == "FeatureCollection"
     assert len(data["features"]) == 1
-    geom = data["features"][0]["geometry"]
+    feature = data["features"][0]
+    geom = feature["geometry"]
     assert geom["type"] == "Point"
     assert geom["coordinates"] == [2.0, 1.0]
+    assert feature["properties"]["icon"] == "car"
 
 
 @pytest.mark.usefixtures("base_make_app")

--- a/tests/test_toggle_analysis.py
+++ b/tests/test_toggle_analysis.py
@@ -13,8 +13,8 @@ def test_toggle_analysis(make_app):
         assert eq.include_in_analysis is True
 
     token = get_csrf(client, "/admin")
-    # Disable inclusion by not sending the checkbox value
-    client.post(f"/admin/toggle_analysis/{eq_id}", data={"csrf_token": token})
+    # Disable inclusion by sending value 0
+    client.post(f"/admin/toggle_analysis/{eq_id}", data={"csrf_token": token, "include": "0"})
 
     with app.app_context():
         assert db.session.get(Equipment, eq_id).include_in_analysis is False
@@ -23,8 +23,10 @@ def test_toggle_analysis(make_app):
     # Enable inclusion by sending checkbox value
     client.post(
         f"/admin/toggle_analysis/{eq_id}",
-        data={"csrf_token": token, "include": "1"},
+        data={"csrf_token": token, "include": "1", "icon": "car"},
     )
 
     with app.app_context():
-        assert db.session.get(Equipment, eq_id).include_in_analysis is True
+        eq = db.session.get(Equipment, eq_id)
+        assert eq.include_in_analysis is True
+        assert eq.marker_icon == "car"


### PR DESCRIPTION
## Résumé
- Ajoute un champ d’icône MDI par équipement configurable depuis l’admin
- Colore l’icône de dernière position en vert si < 1h, sinon gris
- Met à jour automatiquement les bases existantes pour ajouter la colonne `marker_icon`

## Tests
- `flake8 .` (échoue : nombreuses erreurs E501)
- `mypy .` (échoue : stubs manquants pour requests)
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_689c97996e288322aeb58de4aad18ff8