### PR TITLE
Fetch last position dynamically on index

### DIFF
--- a/static/js/index-last.js
+++ b/static/js/index-last.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cells = document.querySelectorAll('[data-last-position]');
+  cells.forEach((cell) => {
+    const equipmentId = cell.dataset.equipmentId;
+    const deltaCell = document.querySelector(
+      `[data-last-delta][data-equipment-id="${equipmentId}"]`,
+    );
+
+    async function update() {
+      try {
+        const resp = await fetch(`/equipment/${equipmentId}/last.geojson`);
+        const data = await resp.json();
+        if (!data.features || data.features.length === 0) {
+          return;
+        }
+        const ts = data.features[0].properties.timestamp;
+        const dt = new Date(ts);
+        cell.textContent = dt.toISOString().replace('T', ' ').substring(0, 19);
+        const now = new Date();
+        const delta = now.getTime() - dt.getTime();
+        const days = Math.floor(delta / 86400000);
+        const hours = Math.floor((delta % 86400000) / 3600000);
+        const minutes = Math.floor((delta % 3600000) / 60000);
+        if (deltaCell) {
+          deltaCell.textContent = `${days} j ${hours} h ${minutes} min`;
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch last position', err);
+      }
+    }
+
+    update();
+    setInterval(update, 60000);
+  });
+});
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,11 +81,11 @@
                 <span class="badge text-bg-warning ms-1">suivi seul</span>
               {% endif %}
             </td>
-            <td>{{ eq.last_seen or '–' }}</td>
+            <td data-last-position data-equipment-id="{{ eq.id }}">{{ eq.last_seen or '–' }}</td>
             <td>{{ eq.total_hectares|round(2) }}</td>
             <td>{{ eq.relative_hectares|round(2) }}</td>
             <td>{{ eq.distance_km|round(2) }}</td>
-            <td>{{ eq.delta_str }}</td>
+            <td data-last-delta data-equipment-id="{{ eq.id }}">{{ eq.delta_str }}</td>
             <td>
               {{ eq.score }}
               {% if eq.rank == 1 %}
@@ -101,6 +101,7 @@
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/index-last.js') }}"></script>
   <script>
     // Améliore la navigation sur mobile (tap unique)
     document.querySelectorAll('.navbar a').forEach(a => {

--- a/tests/test_index_summary.py
+++ b/tests/test_index_summary.py
@@ -41,6 +41,7 @@ def test_index_shows_last_seen_from_positions(make_app):
             )
         )
         db.session.commit()
+        eq_id = eq.id
 
     resp = client.get("/")
     assert resp.status_code == 200
@@ -53,7 +54,13 @@ def test_index_shows_last_seen_from_positions(make_app):
     assert row is not None
     cells = row.find_all("td")
     # Dernière position is the 2nd column
-    assert cells[1].text.strip().startswith("2023-01-01 12:00:00")
+    last_cell = cells[1]
+    assert last_cell.text.strip().startswith("2023-01-01 12:00:00")
+    assert "data-last-position" in last_cell.attrs
+    assert last_cell["data-equipment-id"] == str(eq_id)
+    delta_cell = cells[5]
+    assert "data-last-delta" in delta_cell.attrs
+    assert delta_cell["data-equipment-id"] == str(eq_id)
 
 
 def test_index_uses_computed_total_hectares(make_app):


### PR DESCRIPTION
## Summary
- load last positions asynchronously on the index page
- update elapsed time alongside refreshed timestamps
- test presence of data attributes for dynamic updates

## Testing
- `flake8 .` *(fails: E501 line too long and other pre-existing issues)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_689cad6631488322a5e0ba0ca81e9cb6