### PR TITLE
Simplify OsmAnd JSON payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Exemples d’appels:
 /osmand?deviceid=48241179&lat=45.1234&lon=3.9876&timestamp=2024-08-10T12:34:56Z&token=SECRETTOKEN
 ```
 
-- JSON pour un seul appareil:
+- JSON pour un seul appareil (optionnellement compressé en gzip avec `Content-Encoding: gzip`):
 
 ```
 POST /osmand
@@ -126,21 +126,7 @@ Content-Type: application/json
   ]
 }
 ```
-
-- JSON “bulk” pour plusieurs appareils:
-
-```
-POST /osmand
-Content-Type: application/json
-
-{
-  "devices": [
-    { "device_id": "48241179", "locations": [ {"latitude": 45.1, "longitude": 3.9} ] },
-    { "device_id": "tractor-b", "locations": [ {"coords": {"latitude": 45.2, "longitude": 4.0}, "time": "2024-08-10 13:00:00"} ] }
-  ]
-}
-```
-
+Le même JSON peut être envoyé compressé en gzip en ajoutant l'en-tête `Content-Encoding: gzip`.
 Notes:
 
 - Les timestamps acceptés: UNIX (en secondes ou millisecondes), ISO8601 (`...Z` ou `+00:00`), ou `YYYY-MM-DD HH:MM:SS`.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Notes:
 
 - Les timestamps acceptés: UNIX (en secondes ou millisecondes), ISO8601 (`...Z` ou `+00:00`), ou `YYYY-MM-DD HH:MM:SS`.
 - Les champs `latitude`/`longitude` peuvent être fournis soit directement, soit via `coords: { latitude, longitude }`.
+- Le champ optionnel `battery` (ou `batt`) permet de transmettre le niveau de batterie de l'appareil.
 - L’ingestion OsmAnd met à jour `Equipment.last_position` et ajoute des lignes `Position` mais ne déclenche pas d’analyse immédiate (elle reste planifiée).
 
 ## Production

--- a/models.py
+++ b/models.py
@@ -45,6 +45,7 @@ class Equipment(db.Model):  # type: ignore[name-defined]
     # Surface unique cumulée (zones dédupliquées entre jours)
     relative_hectares = db.Column(db.Float, default=0.0)
     distance_between_zones = db.Column(db.Float, default=0.0)
+    battery_level = db.Column(db.Float, nullable=True)
 
     positions = db.relationship('Position', backref='equipment', lazy=True)
     daily_zones = db.relationship('DailyZone', backref='equipment', lazy=True)

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -220,6 +220,14 @@
             <span class="fw-semibold">Sélectionnez une date</span>
           {% endif %}
         </div>
+        <div class="small text-muted mb-3">
+          Batterie:
+          {% if equipment.battery_level is not none %}
+            <span class="fw-semibold">{{ equipment.battery_level|int }}%</span>
+          {% else %}
+            <span class="fw-semibold">–</span>
+          {% endif %}
+        </div>
         <div class="table-responsive">
           <table id="zones-table" class="table table-striped table-hover">
             <thead>

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,6 +61,7 @@
             <th>Ha traités</th>
             <th>Ha uniques</th>
             <th>Distance zones (km)</th>
+            <th>Batterie</th>
             <th>Temps écoulé</th>
             <th>Score</th>
           </tr>
@@ -85,6 +86,13 @@
             <td>{{ eq.total_hectares|round(2) }}</td>
             <td>{{ eq.relative_hectares|round(2) }}</td>
             <td>{{ eq.distance_km|round(2) }}</td>
+            <td>
+              {% if eq.battery_level is not none %}
+                {{ eq.battery_level|int }}%
+              {% else %}
+                –
+              {% endif %}
+            </td>
             <td>{{ eq.delta_str }}</td>
             <td>
               {{ eq.score }}

--- a/tests/test_last_position_and_source.py
+++ b/tests/test_last_position_and_source.py
@@ -54,33 +54,20 @@ def test_index_source_badge_and_last_geojson(make_app):
 
 
 @pytest.mark.usefixtures("base_make_app")
-def test_osmand_bulk_devices_json(make_app):
+def test_osmand_multiple_locations_json(make_app):
     app = make_app()
     client = app.test_client()
     payload = {
-        "devices": [
-            {
-                "device_id": "bulk-1",
-                "locations": [
-                    {"coords": {"latitude": 10.0, "longitude": 11.0}, "timestamp": "2024-01-01T00:00:00Z"},
-                    {"coords": {"latitude": 10.1, "longitude": 11.1}, "timestamp": "2024-01-01T00:01:00Z"},
-                ],
-            },
-            {
-                "device_id": "bulk-2",
-                "locations": [
-                    {"coords": {"latitude": 20.0, "longitude": 21.0}, "timestamp": "2024-01-01T00:00:00Z"}
-                ],
-            },
-        ]
+        "device_id": "bulk-1",
+        "locations": [
+            {"coords": {"latitude": 10.0, "longitude": 11.0}, "timestamp": "2024-01-01T00:00:00Z"},
+            {"coords": {"latitude": 10.1, "longitude": 11.1}, "timestamp": "2024-01-01T00:01:00Z"},
+        ],
     }
     resp = client.post("/osmand", data=json.dumps(payload), content_type="application/json")
     assert resp.status_code == 200
     with app.app_context():
         eq1 = Equipment.query.filter_by(osmand_id="bulk-1").first()
-        eq2 = Equipment.query.filter_by(osmand_id="bulk-2").first()
-        assert eq1 is not None and eq2 is not None
+        assert eq1 is not None
         c1 = Position.query.filter_by(equipment_id=eq1.id).count()
-        c2 = Position.query.filter_by(equipment_id=eq2.id).count()
         assert c1 == 2
-        assert c2 == 1

--- a/tests/test_osmand_ingest.py
+++ b/tests/test_osmand_ingest.py
@@ -1,10 +1,9 @@
-import json
 import gzip
-from datetime import datetime
+import json
 
 import pytest
 
-from models import db, Equipment, Position
+from models import Equipment, Position
 from tests.utils import login, get_csrf
 
 
@@ -100,6 +99,30 @@ def test_osmand_gzip_json_creates_positions(make_app):
 
 
 @pytest.mark.usefixtures("base_make_app")
+def test_osmand_json_with_battery_updates_equipment(make_app):
+    app = make_app()
+    with app.app_context():
+        client = app.test_client()
+        payload = {
+            "location": {
+                "timestamp": "2024-01-01T00:00:00Z",
+                "coords": {"latitude": 10.0, "longitude": 20.0},
+                "battery": 88,
+            },
+            "device_id": "bat-1",
+        }
+        resp = client.post(
+            "/osmand",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        eq = Equipment.query.filter_by(osmand_id="bat-1").first()
+        assert eq is not None
+        assert eq.battery_level == 88
+
+
+@pytest.mark.usefixtures("base_make_app")
 def test_admin_add_osmand_device(make_app):
     app = make_app()
     client = app.test_client()
@@ -122,4 +145,3 @@ def test_admin_add_osmand_device(make_app):
         assert eq is not None
         assert eq.name == "Tracteur OsmAnd"
         assert eq.token_api == "secret"
-


### PR DESCRIPTION
## Summary
- reject bulk OsmAnd device payloads
- document single-device JSON format with multiple locations and gzip support
- test OsmAnd ingestion with multiple positions and gzipped JSON

## Testing
- `flake8 .` *(fails: E501 line too long and other existing violations)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_689cac4658648322ba7c07a189b4bc00