### PR TITLE
Refresh equipment status automatically

### DIFF
--- a/app.py
+++ b/app.py
@@ -835,20 +835,11 @@ def create_app(
         db.session.commit()
         return ("OK", 200)
 
-    @app.route('/')
-    @login_required
-    def index():
-        # 1) Récupération des équipements
+    def get_equipment_data() -> list[dict[str, Any]]:
         equipments = Equipment.query.all()
-        message = None
-
-        # 2) Plus de lancement manuel d'analyse
-
-        # 3) Préparation des données pour l’affichage
-        equipment_data = []
         now = datetime.now(timezone.utc).replace(tzinfo=None)
+        equipment_data: list[dict[str, Any]] = []
         for eq in equipments:
-            # Fallback pour la dernière position si non renseignée
             last_dt = eq.last_position
             if last_dt is None:
                 last_pos = (
@@ -872,16 +863,10 @@ def create_app(
                 delta_str = "–"
 
             distance_km = (eq.distance_between_zones or 0) / 1000
-            # Utiliser les valeurs mises à jour en tâche de fond
-            total_hectares = (
-                eq.total_hectares or zone.calculate_total_hectares(eq.id)
-            )
+            total_hectares = eq.total_hectares or zone.calculate_total_hectares(eq.id)
             rel_hectares = getattr(eq, "relative_hectares", 0.0) or 0.0
-            ratio_eff = (
-                (total_hectares / distance_km) if distance_km else 0.0
-            )
+            ratio_eff = (total_hectares / distance_km) if distance_km else 0.0
 
-            # Determine data source for display
             if getattr(eq, 'osmand_id', None) and (getattr(eq, 'id_traccar', 0) == 0):
                 source = 'osmand'
             else:
@@ -901,7 +886,6 @@ def create_app(
                 "delta_str": delta_str,
             })
 
-        # Normalisation des critères
         def normalize(values, value, invert=False):
             clean = [v for v in values if v is not None]
             if not clean or value is None:
@@ -940,15 +924,26 @@ def create_app(
             )
 
         equipment_data.sort(key=lambda x: x["score"], reverse=True)
-
         for idx, d in enumerate(equipment_data, start=1):
             d["rank"] = idx
 
+        return equipment_data
+
+    @app.route('/')
+    @login_required
+    def index():
+        message = None
+        equipment_data = get_equipment_data()
         return render_template(
             'index.html',
             equipment_data=equipment_data,
             message=message
         )
+
+    @app.route('/equipment_status')
+    @login_required
+    def equipment_status():
+        return jsonify(get_equipment_data())
 
     @app.route('/equipment/<int:equipment_id>/last.geojson')
     @login_required

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,7 @@
         </thead>
         <tbody>
           {% for eq in equipment_data %}
-          <tr>
+          <tr data-eqid="{{ eq.id }}">
             <td>
               <a href="{{ url_for('equipment_detail', equipment_id=eq.id) }}">
                 {{ eq.name }}
@@ -81,11 +81,11 @@
                 <span class="badge text-bg-warning ms-1">suivi seul</span>
               {% endif %}
             </td>
-            <td>{{ eq.last_seen or '–' }}</td>
+            <td class="last-seen">{{ eq.last_seen or '–' }}</td>
             <td>{{ eq.total_hectares|round(2) }}</td>
             <td>{{ eq.relative_hectares|round(2) }}</td>
             <td>{{ eq.distance_km|round(2) }}</td>
-            <td>{{ eq.delta_str }}</td>
+            <td class="delta">{{ eq.delta_str }}</td>
             <td>
               {{ eq.score }}
               {% if eq.rank == 1 %}
@@ -106,6 +106,34 @@
     document.querySelectorAll('.navbar a').forEach(a => {
       a.addEventListener('touchend', function () { window.location.href = this.href; });
     });
+  </script>
+  <script>
+    async function refreshStatus() {
+      try {
+        const resp = await fetch('{{ url_for('equipment_status') }}');
+        if (!resp.ok) {
+          return;
+        }
+        const data = await resp.json();
+        data.forEach(eq => {
+          const row = document.querySelector(`tr[data-eqid="${eq.id}"]`);
+          if (!row) {
+            return;
+          }
+          const last = row.querySelector('.last-seen');
+          const delta = row.querySelector('.delta');
+          if (last) {
+            last.textContent = eq.last_seen || '–';
+          }
+          if (delta) {
+            delta.textContent = eq.delta_str;
+          }
+        });
+      } catch (e) {
+        console.error('refreshStatus', e);
+      }
+    }
+    setInterval(refreshStatus, 10000);
   </script>
 </body>
 </html>

--- a/tests/test_equipment_status_api.py
+++ b/tests/test_equipment_status_api.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+import pytest
+
+from models import db, Equipment, Position
+from tests.utils import login
+
+
+@pytest.mark.usefixtures("base_make_app")
+def test_equipment_status_updates(make_app):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        ts1 = datetime(2023, 1, 1, 10, 0, 0)
+        db.session.add(
+            Position(
+                equipment_id=eq.id,
+                latitude=0.0,
+                longitude=0.0,
+                timestamp=ts1,
+            )
+        )
+        eq.last_position = ts1
+        db.session.commit()
+
+    r1 = client.get("/equipment_status")
+    assert r1.status_code == 200
+    data1 = r1.get_json()
+    assert data1[0]["last_seen"].startswith("2023-01-01 10:00:00")
+
+    with app.app_context():
+        eq = Equipment.query.first()
+        ts2 = datetime(2023, 1, 1, 11, 0, 0)
+        db.session.add(
+            Position(
+                equipment_id=eq.id,
+                latitude=1.0,
+                longitude=1.0,
+                timestamp=ts2,
+            )
+        )
+        eq.last_position = ts2
+        db.session.commit()
+
+    r2 = client.get("/equipment_status")
+    assert r2.status_code == 200
+    data2 = r2.get_json()
+    assert data2[0]["last_seen"].startswith("2023-01-01 11:00:00")


### PR DESCRIPTION
## Summary
- expose `/equipment_status` endpoint returning latest equipment metrics
- refresh last position and elapsed time in index table via periodic fetch
- test equipment status API updates when new positions arrive

## Testing
- `flake8 .` *(fails: E501 line too long in existing files)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_689cc0aa7acc8322afcbed81ad1a906b