### PR TITLE
Simplify OsmAnd JSON payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Notes:
 
 - Les timestamps acceptés: UNIX (en secondes ou millisecondes), ISO8601 (`...Z` ou `+00:00`), ou `YYYY-MM-DD HH:MM:SS`.
 - Les champs `latitude`/`longitude` peuvent être fournis soit directement, soit via `coords: { latitude, longitude }`.
-- Le champ optionnel `battery` (ou `batt`) permet de transmettre le niveau de batterie de l'appareil.
+- Le champ optionnel `battery` (ou `batt`) permet de transmettre le niveau de batterie de l'appareil. Il peut être un nombre (0‑100 ou 0–1) ou un objet `{ "level": ... }` ; seule la valeur de `level` est prise en compte.
 - L’ingestion OsmAnd met à jour `Equipment.last_position` et ajoute des lignes `Position` mais ne déclenche pas d’analyse immédiate (elle reste planifiée).
 
 ## Production

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Notes:
 - Les champs `latitude`/`longitude` peuvent être fournis soit directement, soit via `coords: { latitude, longitude }`.
 - Le champ optionnel `battery` (ou `batt`) permet de transmettre le niveau de batterie de l'appareil. Il peut être un nombre (0‑100 ou 0–1) ou un objet `{ "level": ... }` ; seule la valeur de `level` est prise en compte.
 - L’ingestion OsmAnd met à jour `Equipment.last_position` et ajoute des lignes `Position` mais ne déclenche pas d’analyse immédiate (elle reste planifiée).
+- Lors du polling Traccar, si les positions contiennent `batteryLevel` ou `battery` dans `attributes`, ce niveau est également enregistré.
 
 ## Production
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Exemples d’appels:
 /osmand?deviceid=48241179&lat=45.1234&lon=3.9876&timestamp=2024-08-10T12:34:56Z&token=SECRETTOKEN
 ```
 
-- JSON pour un seul appareil:
+- JSON pour un seul appareil (optionnellement compressé en gzip avec `Content-Encoding: gzip`):
 
 ```
 POST /osmand
@@ -126,25 +126,12 @@ Content-Type: application/json
   ]
 }
 ```
-
-- JSON “bulk” pour plusieurs appareils:
-
-```
-POST /osmand
-Content-Type: application/json
-
-{
-  "devices": [
-    { "device_id": "48241179", "locations": [ {"latitude": 45.1, "longitude": 3.9} ] },
-    { "device_id": "tractor-b", "locations": [ {"coords": {"latitude": 45.2, "longitude": 4.0}, "time": "2024-08-10 13:00:00"} ] }
-  ]
-}
-```
-
+Le même JSON peut être envoyé compressé en gzip en ajoutant l'en-tête `Content-Encoding: gzip`.
 Notes:
 
 - Les timestamps acceptés: UNIX (en secondes ou millisecondes), ISO8601 (`...Z` ou `+00:00`), ou `YYYY-MM-DD HH:MM:SS`.
 - Les champs `latitude`/`longitude` peuvent être fournis soit directement, soit via `coords: { latitude, longitude }`.
+- Le champ optionnel `battery` (ou `batt`) permet de transmettre le niveau de batterie de l'appareil.
 - L’ingestion OsmAnd met à jour `Equipment.last_position` et ajoute des lignes `Position` mais ne déclenche pas d’analyse immédiate (elle reste planifiée).
 
 ## Production

--- a/app.py
+++ b/app.py
@@ -760,6 +760,8 @@ def create_app(
                     continue
                 ts_val = entry.get('timestamp') or entry.get('time')
                 batt_val = entry.get('battery') or entry.get('batt')
+                if isinstance(batt_val, dict):
+                    batt_val = batt_val.get('level')
                 try:
                     ts = _parse_timestamp(ts_val) if ts_val is not None else datetime.utcnow()
                 except BadRequest:
@@ -784,7 +786,10 @@ def create_app(
                     latest_ts = ts_naive
                 if batt_val is not None:
                     try:
-                        eq.battery_level = float(batt_val)
+                        batt_float = float(batt_val)
+                        if batt_float <= 1:
+                            batt_float *= 100
+                        eq.battery_level = batt_float
                         app.logger.info(
                             "Device %s battery at %.0f%%",
                             device_id,

--- a/app.py
+++ b/app.py
@@ -785,8 +785,17 @@ def create_app(
                 if batt_val is not None:
                     try:
                         eq.battery_level = float(batt_val)
+                        app.logger.info(
+                            "Device %s battery at %.0f%%",
+                            device_id,
+                            eq.battery_level,
+                        )
                     except (TypeError, ValueError):
-                        pass
+                        app.logger.info(
+                            "Ignoring invalid battery level %r for device %s",
+                            batt_val,
+                            device_id,
+                        )
             if latest_ts is not None:
                 eq.last_position = latest_ts
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ import os
 import logging
 import time
 import threading
+import json
+import gzip
 
 import requests
 from flask import Flask, render_template, request, redirect, url_for, jsonify
@@ -216,6 +218,13 @@ def create_app(
                         text(
                             "ALTER TABLE equipment ADD COLUMN marker_icon "
                             "VARCHAR DEFAULT 'tractor'"
+                        )
+                    )
+            if "battery_level" not in equip_cols:
+                with db.engine.begin() as conn:
+                    conn.execute(
+                        text(
+                            "ALTER TABLE equipment ADD COLUMN battery_level FLOAT"
                         )
                     )
         if "position" in tables:
@@ -733,7 +742,7 @@ def create_app(
     @csrf.exempt
     @app.route('/osmand', methods=['GET', 'POST'])
     def osmand_ingest():
-        # Accept OsmAnd-like payloads: query params, single JSON, or bulk devices JSON
+        # Accept OsmAnd-like payloads: query params or JSON for a single device
         def ingest_one(device_id: str, locs: list[dict]) -> None:
             eq = _ensure_equipment(str(device_id))
             if not _auth_ok(eq):
@@ -750,6 +759,7 @@ def create_app(
                 if lat is None or lon is None:
                     continue
                 ts_val = entry.get('timestamp') or entry.get('time')
+                batt_val = entry.get('battery') or entry.get('batt')
                 try:
                     ts = _parse_timestamp(ts_val) if ts_val is not None else datetime.utcnow()
                 except BadRequest:
@@ -772,22 +782,29 @@ def create_app(
                     )
                 if latest_ts is None or ts_naive > latest_ts:
                     latest_ts = ts_naive
+                if batt_val is not None:
+                    try:
+                        eq.battery_level = float(batt_val)
+                    except (TypeError, ValueError):
+                        pass
             if latest_ts is not None:
                 eq.last_position = latest_ts
 
-        if request.is_json:
-            data = request.get_json(silent=True) or {}
-            # Bulk shape: { devices: [ { device_id, locations: [...] }, ... ] }
+        raw = request.get_data() or b""
+        if request.headers.get('Content-Encoding') == 'gzip':
+            try:
+                raw = gzip.decompress(raw)
+            except OSError:
+                raise BadRequest('Invalid gzip payload')
+        data = None
+        if raw:
+            try:
+                data = json.loads(raw.decode('utf-8'))
+            except Exception:
+                data = None
+        if isinstance(data, dict):
             if isinstance(data.get('devices'), list):
-                for dev in data['devices']:
-                    did = dev.get('device_id') or dev.get('deviceid') or dev.get('id')
-                    locs = dev.get('locations') or []
-                    if not did or not isinstance(locs, list):
-                        continue
-                    ingest_one(str(did), locs)
-                db.session.commit()
-                return ("OK", 200)
-            # Single device payload
+                return ("Multiple devices not supported", 400)
             device_id = data.get('device_id') or data.get('deviceid') or data.get('id')
             locations: list[dict] = []
             if 'locations' in data and isinstance(data['locations'], list):
@@ -813,6 +830,7 @@ def create_app(
                     'longitude': float(form.get('lon')),
                 },
                 'timestamp': ts or datetime.utcnow().isoformat() + 'Z',
+                'battery': form.get('battery') or form.get('batt'),
             })
         elif form.get('location'):
             try:
@@ -824,6 +842,7 @@ def create_app(
                         'longitude': float(lon_s.strip()),
                     },
                     'timestamp': ts or datetime.utcnow().isoformat() + 'Z',
+                    'battery': form.get('battery') or form.get('batt'),
                 })
             except Exception:
                 raise BadRequest('Invalid location parameter')
@@ -899,6 +918,7 @@ def create_app(
                 "delta_seconds": delta_seconds,
                 "ratio_eff": ratio_eff,
                 "delta_str": delta_str,
+                "battery_level": eq.battery_level,
             })
 
         # Normalisation des critères

--- a/models.py
+++ b/models.py
@@ -45,6 +45,7 @@ class Equipment(db.Model):  # type: ignore[name-defined]
     # Surface unique cumulée (zones dédupliquées entre jours)
     relative_hectares = db.Column(db.Float, default=0.0)
     distance_between_zones = db.Column(db.Float, default=0.0)
+    battery_level = db.Column(db.Float, nullable=True)
 
     positions = db.relationship('Position', backref='equipment', lazy=True)
     daily_zones = db.relationship('DailyZone', backref='equipment', lazy=True)

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -220,6 +220,14 @@
             <span class="fw-semibold">Sélectionnez une date</span>
           {% endif %}
         </div>
+        <div class="small text-muted mb-3">
+          Batterie:
+          {% if equipment.battery_level is not none %}
+            <span class="fw-semibold">{{ equipment.battery_level|int }}%</span>
+          {% else %}
+            <span class="fw-semibold">–</span>
+          {% endif %}
+        </div>
         <div class="table-responsive">
           <table id="zones-table" class="table table-striped table-hover">
             <thead>

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,6 +61,7 @@
             <th>Ha traités</th>
             <th>Ha uniques</th>
             <th>Distance zones (km)</th>
+            <th>Batterie</th>
             <th>Temps écoulé</th>
             <th>Score</th>
           </tr>
@@ -85,6 +86,13 @@
             <td>{{ eq.total_hectares|round(2) }}</td>
             <td>{{ eq.relative_hectares|round(2) }}</td>
             <td>{{ eq.distance_km|round(2) }}</td>
+            <td>
+              {% if eq.battery_level is not none %}
+                {{ eq.battery_level|int }}%
+              {% else %}
+                –
+              {% endif %}
+            </td>
             <td>{{ eq.delta_str }}</td>
             <td>
               {{ eq.score }}

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -5,7 +5,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from tests.utils import login  # noqa: E402
+from tests.utils import login, get_csrf  # noqa: E402
 
 
 def test_post_without_csrf_returns_400(make_app):
@@ -14,3 +14,17 @@ def test_post_without_csrf_returns_400(make_app):
     login(client)
     resp = client.post("/admin", data={"base_url": "http://new.com"})
     assert resp.status_code == 400
+
+
+def test_logout_requires_csrf(make_app):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+
+    # Missing token should return 400
+    resp = client.post("/logout")
+    assert resp.status_code == 400
+
+    token = get_csrf(client, "/")
+    resp = client.post("/logout", data={"csrf_token": token})
+    assert resp.status_code in (200, 302, 303)

--- a/tests/test_last_position_and_source.py
+++ b/tests/test_last_position_and_source.py
@@ -19,16 +19,37 @@ def test_index_source_badge_and_last_geojson(make_app):
         eq.id_traccar = eq.id_traccar or 1
         eq.osmand_id = None
         eq.marker_icon = 'car'
+        eq.battery_level = 50.0
         # Add a last position
         ts = datetime(2023, 1, 1, 15, 0, 0)
-        db.session.add(Position(equipment_id=eq.id, latitude=1.0, longitude=2.0, timestamp=ts))
+        db.session.add(
+            Position(
+                equipment_id=eq.id,
+                latitude=1.0,
+                longitude=2.0,
+                timestamp=ts,
+            )
+        )
         db.session.commit()
 
         # Create a direct OsmAnd device
-        osm = Equipment(id_traccar=0, name="OsmAnd Dev", osmand_id="osm-1")
+        osm = Equipment(
+            id_traccar=0,
+            name="OsmAnd Dev",
+            osmand_id="osm-1",
+            battery_level=80.0,
+        )
         db.session.add(osm)
         db.session.flush()  # ensure osm.id is available
-        db.session.add(Position(equipment_id=osm.id, latitude=3.0, longitude=4.0, timestamp=ts))
+        osm_id = osm.id
+        db.session.add(
+            Position(
+                equipment_id=osm_id,
+                latitude=3.0,
+                longitude=4.0,
+                timestamp=ts,
+            )
+        )
         db.session.commit()
 
     # Check index badges
@@ -37,10 +58,16 @@ def test_index_source_badge_and_last_geojson(make_app):
     html = resp.data.decode()
     assert "Traccar" in html
     assert "OsmAnd" in html
+    assert "50%" in html
+    assert "80%" in html
 
     # Check last.geojson endpoint
     with app.app_context():
-        eq_id = Equipment.query.filter(Equipment.osmand_id.is_(None)).first().id
+        eq_id = (
+            Equipment.query.filter(Equipment.osmand_id.is_(None))
+            .first()
+            .id
+        )
     r2 = client.get(f"/equipment/{eq_id}/last.geojson")
     assert r2.status_code == 200
     data = r2.get_json()
@@ -52,35 +79,36 @@ def test_index_source_badge_and_last_geojson(make_app):
     assert geom["coordinates"] == [2.0, 1.0]
     assert feature["properties"]["icon"] == "car"
 
+    # Equipment detail page shows battery
+    r3 = client.get(f"/equipment/{osm_id}")
+    assert r3.status_code == 200
+    html2 = r3.data.decode()
+    assert "80%" in html2
+
 
 @pytest.mark.usefixtures("base_make_app")
-def test_osmand_bulk_devices_json(make_app):
+def test_osmand_multiple_locations_json(make_app):
     app = make_app()
     client = app.test_client()
     payload = {
-        "devices": [
+        "device_id": "bulk-1",
+        "locations": [
             {
-                "device_id": "bulk-1",
-                "locations": [
-                    {"coords": {"latitude": 10.0, "longitude": 11.0}, "timestamp": "2024-01-01T00:00:00Z"},
-                    {"coords": {"latitude": 10.1, "longitude": 11.1}, "timestamp": "2024-01-01T00:01:00Z"},
-                ],
+                "coords": {"latitude": 10.0, "longitude": 11.0},
+                "timestamp": "2024-01-01T00:00:00Z",
             },
             {
-                "device_id": "bulk-2",
-                "locations": [
-                    {"coords": {"latitude": 20.0, "longitude": 21.0}, "timestamp": "2024-01-01T00:00:00Z"}
-                ],
+                "coords": {"latitude": 10.1, "longitude": 11.1},
+                "timestamp": "2024-01-01T00:01:00Z",
             },
-        ]
+        ],
     }
-    resp = client.post("/osmand", data=json.dumps(payload), content_type="application/json")
+    resp = client.post(
+        "/osmand", data=json.dumps(payload), content_type="application/json"
+    )
     assert resp.status_code == 200
     with app.app_context():
         eq1 = Equipment.query.filter_by(osmand_id="bulk-1").first()
-        eq2 = Equipment.query.filter_by(osmand_id="bulk-2").first()
-        assert eq1 is not None and eq2 is not None
+        assert eq1 is not None
         c1 = Position.query.filter_by(equipment_id=eq1.id).count()
-        c2 = Position.query.filter_by(equipment_id=eq2.id).count()
         assert c1 == 2
-        assert c2 == 1

--- a/tests/test_osmand_ingest.py
+++ b/tests/test_osmand_ingest.py
@@ -124,6 +124,30 @@ def test_osmand_json_with_battery_updates_equipment(make_app):
 
 
 @pytest.mark.usefixtures("base_make_app")
+def test_osmand_json_with_battery_object(make_app):
+    app = make_app()
+    with app.app_context():
+        client = app.test_client()
+        payload = {
+            "location": {
+                "timestamp": "2024-01-01T00:00:00Z",
+                "coords": {"latitude": 10.0, "longitude": 20.0},
+                "battery": {"level": 0.44, "is_charging": False},
+            },
+            "device_id": "bat-obj",
+        }
+        resp = client.post(
+            "/osmand",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        eq = Equipment.query.filter_by(osmand_id="bat-obj").first()
+        assert eq is not None
+        assert eq.battery_level == 44
+
+
+@pytest.mark.usefixtures("base_make_app")
 def test_osmand_json_logs_battery_level(make_app, caplog):
     app = make_app()
     with app.app_context():
@@ -132,7 +156,7 @@ def test_osmand_json_logs_battery_level(make_app, caplog):
             "location": {
                 "timestamp": "2024-01-01T00:00:00Z",
                 "coords": {"latitude": 10.0, "longitude": 20.0},
-                "battery": 55,
+                "battery": {"level": 0.55},
             },
             "device_id": "log-1",
         }

--- a/tests/test_traccar_battery.py
+++ b/tests/test_traccar_battery.py
@@ -1,0 +1,24 @@
+import pytest
+import zone
+from models import Equipment
+
+
+@pytest.mark.usefixtures("base_make_app")
+def test_polling_updates_battery_from_traccar(make_app, monkeypatch):
+    app = make_app()
+
+    def fake_fetch(device_id, start, end):
+        return [
+            {
+                "deviceTime": "2024-01-01T00:00:00Z",
+                "latitude": 1.0,
+                "longitude": 2.0,
+                "attributes": {"batteryLevel": 77},
+            }
+        ]
+
+    monkeypatch.setattr(zone, "fetch_positions", fake_fetch)
+    app.poll_latest_positions()
+    with app.app_context():
+        eq = Equipment.query.filter_by(id_traccar=1).first()
+        assert eq.battery_level == 77


### PR DESCRIPTION
## Summary
- reject bulk OsmAnd device payloads
- document single-device JSON format with multiple locations, optional battery level and gzip support
- test OsmAnd ingestion with multiple positions, gzipped JSON and battery updates
- allow OsmAnd payloads to store battery level on equipment and show it in the UI
- ensure logout requests include a CSRF token with a regression test

## Testing
- `flake8 .` *(fails: E501 line too long and other existing violations)*
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_689cac4658648322ba7c07a189b4bc00