### PR TITLE
Split admin into subpages

### DIFF
--- a/templates/admin_analysis.html
+++ b/templates/admin_analysis.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Admin - Paramètres de l'analyse</title>
+  <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
+</head>
+<body>
+  <nav class="navbar navbar-expand-md navbar-light top-bar mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="Accueil" height="40">
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
+          {% if current_user.is_admin %}
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="bi bi-speedometer2 me-1"></i> Admin
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="{{ url_for('admin_equipment') }}">Gestion des équipements</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_analysis') }}">Paramètres de l'analyse</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('users') }}">Gestion des utilisateurs</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_traccar') }}">Paramètres Traccar</a></li>
+            </ul>
+          </li>
+          {% endif %}
+          <li class="nav-item">
+            <form method="post" action="{{ url_for('logout') }}" class="d-inline">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit" class="nav-link btn btn-link p-0 d-flex align-items-center">
+                <i class="bi bi-box-arrow-right me-1"></i> Déconnexion
+              </button>
+            </form>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container">
+    <h1 class="h3 mb-4"><i class="bi bi-graph-up me-2"></i>Paramètres de l'analyse</h1>
+
+    <div id="analysis-banner" class="alert text-center mb-3 {% if error %}alert-danger{% else %}alert-info{% endif %}" role="alert" style="{% if not message and not error %}display:none{% endif %}">
+      {% if message %}{{ message }}{% elif error %}{{ error }}{% endif %}
+    </div>
+
+    <form method="post" class="mt-3" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+      <div class="mb-4">
+        <label for="analysis_hour" class="form-label fw-bold">Heure d'analyse automatique (0-23)</label>
+        <input type="number" class="form-control {% if form and form.analysis_hour.errors %}is-invalid{% endif %}" id="analysis_hour" name="analysis_hour" min="0" max="23" value="{{ existing_hour }}">
+        {% if form and form.analysis_hour.errors %}
+        <div class="invalid-feedback">{{ form.analysis_hour.errors[0] }}</div>
+        {% endif %}
+      </div>
+
+      <h5 class="mb-2"><i class="bi bi-diagram-2 me-2"></i>Paramètres des zones :</h5>
+      <div class="mb-3">
+        <label for="eps_meters" class="form-label fw-bold">
+          Distance de clustering (m)
+          <span class="text-info" data-bs-toggle="tooltip" title="Distance maximale entre deux points pour appartenir au même cluster.">?</span>
+        </label>
+        <input type="number" class="form-control {% if form and form.eps_meters.errors %}is-invalid{% endif %}" id="eps_meters" name="eps_meters" step="0.1" min="1" value="{{ existing_eps }}">
+        {% if form and form.eps_meters.errors %}
+        <div class="invalid-feedback">{{ form.eps_meters.errors[0] }}</div>
+        {% endif %}
+      </div>
+      <div class="mb-3">
+        <label for="min_surface" class="form-label fw-bold">
+          Surface minimale (ha)
+          <span class="text-info" data-bs-toggle="tooltip" title="Seules les zones dépassant cette surface seront retenues.">?</span>
+        </label>
+        <input type="number" class="form-control {% if form and form.min_surface.errors %}is-invalid{% endif %}" id="min_surface" name="min_surface" step="0.01" min="0" value="{{ existing_surface }}">
+        {% if form and form.min_surface.errors %}
+        <div class="invalid-feedback">{{ form.min_surface.errors[0] }}</div>
+        {% endif %}
+      </div>
+      <div class="mb-4">
+        <label for="alpha_shape" class="form-label fw-bold">
+          Paramètre alpha
+          <span class="text-info" data-bs-toggle="tooltip" title="Contrôle la forme de l'enveloppe alpha-shape. Plus petit = plus détaillé.">?</span>
+        </label>
+        <input type="number" class="form-control {% if form and form.alpha_shape.errors %}is-invalid{% endif %}" id="alpha_shape" name="alpha_shape" step="0.01" min="0" value="{{ existing_alpha }}">
+        {% if form and form.alpha_shape.errors %}
+        <div class="invalid-feedback">{{ form.alpha_shape.errors[0] }}</div>
+        {% endif %}
+      </div>
+
+      <button type="submit" class="btn btn-primary">Enregistrer</button>
+    </form>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    document.querySelectorAll('.navbar a').forEach(a => {
+      a.addEventListener('touchend', function () { window.location.href = this.href; });
+    });
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    [...tooltipTriggerList].forEach(el => new bootstrap.Tooltip(el));
+  </script>
+</body>
+</html>

--- a/templates/admin_equipment.html
+++ b/templates/admin_equipment.html
@@ -23,15 +23,16 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
           {% if current_user.is_admin %}
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('admin') }}">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               <i class="bi bi-speedometer2 me-1"></i> Admin
             </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('users') }}">
-              <i class="bi bi-people me-1"></i> Utilisateurs
-            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="{{ url_for('admin_equipment') }}">Gestion des équipements</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_analysis') }}">Paramètres de l'analyse</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('users') }}">Gestion des utilisateurs</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_traccar') }}">Paramètres Traccar</a></li>
+            </ul>
           </li>
           {% endif %}
           <li class="nav-item">
@@ -61,74 +62,6 @@
 
     <form method="post" class="mt-3" novalidate>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <!-- Adresse serveur -->
-      <div class="mb-3">
-        <label for="base_url" class="form-label fw-bold">Adresse du serveur</label>
-        <input type="text"
-               class="form-control {% if form and form.base_url.errors %}is-invalid{% endif %}"
-               id="base_url"
-               name="base_url"
-               placeholder="https://traccar.example.com"
-               value="{{ existing_url }}">
-        {% if form and form.base_url.errors %}
-        <div class="invalid-feedback">{{ form.base_url.errors[0] }}</div>
-        {% endif %}
-      </div>
-      <!-- Token commun -->
-      <div class="mb-4">
-        <label for="token_global" class="form-label fw-bold">Token API Traccar</label>
-        <input type="text"
-               class="form-control {% if form and form.token_global.errors %}is-invalid{% endif %}"
-               id="token_global"
-               name="token_global"
-               placeholder="Collez ici le token Bearer…"
-               value="">
-        {% if form and form.token_global.errors %}
-        <div class="invalid-feedback">{{ form.token_global.errors[0] }}</div>
-        {% endif %}
-      </div>
-
-      <!-- Heure analyse automatique -->
-      <div class="mb-4">
-        <label for="analysis_hour" class="form-label fw-bold">Heure d'analyse automatique (0-23)</label>
-        <input type="number" class="form-control {% if form and form.analysis_hour.errors %}is-invalid{% endif %}" id="analysis_hour" name="analysis_hour" min="0" max="23" value="{{ existing_hour }}">
-        {% if form and form.analysis_hour.errors %}
-        <div class="invalid-feedback">{{ form.analysis_hour.errors[0] }}</div>
-        {% endif %}
-      </div>
-
-        <!-- Paramètres de calcul des zones -->
-        <h5 class="mb-2"><i class="bi bi-diagram-2 me-2"></i>Paramètres des zones :</h5>
-      <div class="mb-3">
-        <label for="eps_meters" class="form-label fw-bold">
-          Distance de clustering (m)
-          <span class="text-info" data-bs-toggle="tooltip" title="Distance maximale entre deux points pour appartenir au même cluster.">?</span>
-        </label>
-        <input type="number" class="form-control {% if form and form.eps_meters.errors %}is-invalid{% endif %}" id="eps_meters" name="eps_meters" step="0.1" min="1" value="{{ existing_eps }}">
-        {% if form and form.eps_meters.errors %}
-        <div class="invalid-feedback">{{ form.eps_meters.errors[0] }}</div>
-        {% endif %}
-      </div>
-      <div class="mb-3">
-        <label for="min_surface" class="form-label fw-bold">
-          Surface minimale (ha)
-          <span class="text-info" data-bs-toggle="tooltip" title="Seules les zones dépassant cette surface seront retenues.">?</span>
-        </label>
-        <input type="number" class="form-control {% if form and form.min_surface.errors %}is-invalid{% endif %}" id="min_surface" name="min_surface" step="0.01" min="0" value="{{ existing_surface }}">
-        {% if form and form.min_surface.errors %}
-        <div class="invalid-feedback">{{ form.min_surface.errors[0] }}</div>
-        {% endif %}
-      </div>
-      <div class="mb-4">
-        <label for="alpha_shape" class="form-label fw-bold">
-          Paramètre alpha
-          <span class="text-info" data-bs-toggle="tooltip" title="Contrôle la forme de l'enveloppe alpha-shape. Plus petit = plus détaillé.">?</span>
-        </label>
-        <input type="number" class="form-control {% if form and form.alpha_shape.errors %}is-invalid{% endif %}" id="alpha_shape" name="alpha_shape" step="0.01" min="0" value="{{ existing_alpha }}">
-        {% if form and form.alpha_shape.errors %}
-        <div class="invalid-feedback">{{ form.alpha_shape.errors[0] }}</div>
-        {% endif %}
-      </div>
 
       <h5 class="mt-4 mb-3"><i class="bi bi-sliders me-2"></i>Options par équipement</h5>
       <div class="input-group mb-3">

--- a/templates/admin_traccar.html
+++ b/templates/admin_traccar.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Admin - Paramètres Traccar</title>
+  <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
+</head>
+<body>
+  <nav class="navbar navbar-expand-md navbar-light top-bar mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="Accueil" height="40">
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
+          {% if current_user.is_admin %}
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="bi bi-speedometer2 me-1"></i> Admin
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="{{ url_for('admin_equipment') }}">Gestion des équipements</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_analysis') }}">Paramètres de l'analyse</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('users') }}">Gestion des utilisateurs</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_traccar') }}">Paramètres Traccar</a></li>
+            </ul>
+          </li>
+          {% endif %}
+          <li class="nav-item">
+            <form method="post" action="{{ url_for('logout') }}" class="d-inline">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit" class="nav-link btn btn-link p-0 d-flex align-items-center">
+                <i class="bi bi-box-arrow-right me-1"></i> Déconnexion
+              </button>
+            </form>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container">
+    <h1 class="h3 mb-4"><i class="bi bi-hdd-network me-2"></i>Paramètres Traccar</h1>
+
+    <div id="analysis-banner" class="alert text-center mb-3 {% if error %}alert-danger{% else %}alert-info{% endif %}" role="alert" style="{% if not message and not error %}display:none{% endif %}">
+      {% if message %}{{ message }}{% elif error %}{{ error }}{% endif %}
+    </div>
+
+    <form method="post" class="mt-3" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="mb-3">
+        <label for="base_url" class="form-label fw-bold">Adresse du serveur</label>
+        <input type="text" class="form-control {% if form and form.base_url.errors %}is-invalid{% endif %}" id="base_url" name="base_url" placeholder="https://traccar.example.com" value="{{ existing_url }}">
+        {% if form and form.base_url.errors %}
+        <div class="invalid-feedback">{{ form.base_url.errors[0] }}</div>
+        {% endif %}
+      </div>
+      <div class="mb-4">
+        <label for="token_global" class="form-label fw-bold">Token API Traccar</label>
+        <input type="text" class="form-control {% if form and form.token_global.errors %}is-invalid{% endif %}" id="token_global" name="token_global" placeholder="Collez ici le token Bearer…" value="">
+        {% if form and form.token_global.errors %}
+        <div class="invalid-feedback">{{ form.token_global.errors[0] }}</div>
+        {% endif %}
+      </div>
+      <button type="submit" class="btn btn-primary">Enregistrer</button>
+    </form>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    document.querySelectorAll('.navbar a').forEach(a => {
+      a.addEventListener('touchend', function () { window.location.href = this.href; });
+    });
+  </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,15 +24,16 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
           {% if current_user.is_admin %}
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('admin') }}">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               <i class="bi bi-speedometer2 me-1"></i> Admin
             </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('users') }}">
-              <i class="bi bi-people me-1"></i> Utilisateurs
-            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="{{ url_for('admin_equipment') }}">Gestion des équipements</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_analysis') }}">Paramètres de l'analyse</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('users') }}">Gestion des utilisateurs</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_traccar') }}">Paramètres Traccar</a></li>
+            </ul>
           </li>
           {% endif %}
           <li class="nav-item">

--- a/templates/users.html
+++ b/templates/users.html
@@ -21,15 +21,16 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-md-auto mb-2 mb-md-0">
           {% if current_user.is_admin %}
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('admin') }}">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               <i class="bi bi-speedometer2 me-1"></i> Admin
             </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('users') }}">
-              <i class="bi bi-people me-1"></i> Utilisateurs
-            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="{{ url_for('admin_equipment') }}">Gestion des équipements</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_analysis') }}">Paramètres de l'analyse</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('users') }}">Gestion des utilisateurs</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('admin_traccar') }}">Paramètres Traccar</a></li>
+            </ul>
           </li>
           {% endif %}
           <li class="nav-item">

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -23,18 +23,12 @@ def test_admin_updates_server_url(make_app, monkeypatch):
     login(client)
     devices = [{"id": 1, "name": "eq"}]
     monkeypatch.setattr(zone, "fetch_devices", lambda: devices)
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/traccar")
     resp = client.post(
-        "/admin",
+        "/admin/traccar",
         data={
             "base_url": "http://new.com",
             "token_global": "tok",
-            "follow_t1": "1",
-            "type_t1": "tractor",
-            "include_t1": "1",
-            "eps_meters": "30",
-            "min_surface": "0.2",
-            "alpha_shape": "0.05",
             "csrf_token": token,
         },
     )
@@ -43,9 +37,6 @@ def test_admin_updates_server_url(make_app, monkeypatch):
         cfg = Config.query.first()
         assert cfg.traccar_url == "http://new.com"
         assert cfg.traccar_token == "tok"
-        assert cfg.eps_meters == 30
-        assert cfg.min_surface_ha == 0.2
-        assert cfg.alpha == 0.05
 
 
 def test_admin_updates_analysis_hour(make_app, monkeypatch):
@@ -53,9 +44,9 @@ def test_admin_updates_analysis_hour(make_app, monkeypatch):
     client = app.test_client()
     login(client)
     monkeypatch.setattr(zone, "fetch_devices", lambda: [])
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/analysis")
     resp = client.post(
-        "/admin",
+        "/admin/analysis",
         data={"analysis_hour": "5", "csrf_token": token},
     )
     assert resp.status_code == 200
@@ -101,7 +92,7 @@ def test_admin_handles_fetch_error(make_app, monkeypatch):
         raise zone.requests.exceptions.HTTPError("401")
 
     monkeypatch.setattr(zone, "fetch_devices", fake_fetch_devices)
-    resp = client.get("/admin")
+    resp = client.get("/admin/equipment")
     assert resp.status_code == 200
     assert (
         "Impossible de récupérer les équipements"
@@ -114,7 +105,7 @@ def test_admin_page_has_status_poll(make_app, monkeypatch):
     client = app.test_client()
     login(client)
     monkeypatch.setattr(zone, "fetch_devices", lambda: [])
-    resp = client.get("/admin")
+    resp = client.get("/admin/equipment")
     html = resp.get_data(as_text=True)
     assert "credentials: 'same-origin'" in html
     assert 'id="analysis-banner"' in html
@@ -144,29 +135,12 @@ def test_reanalyze_saves_params(make_app, monkeypatch):
 
     monkeypatch.setattr(threading, "Thread", InstantThread)
 
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post(
         "/reanalyze_all",
-        data={
-            "base_url": "http://new.com",
-            "token_global": "tok",
-            "follow_t1": "1",
-            "type_t1": "tractor",
-            "include_t1": "1",
-            "eps_meters": "40",
-            "min_surface": "0.3",
-            "alpha_shape": "0.07",
-            "csrf_token": token,
-        },
+        data={"csrf_token": token},
     )
     assert resp.status_code == 302
-    with app.app_context():
-        cfg = Config.query.first()
-        assert cfg.traccar_url == "http://new.com"
-        assert cfg.traccar_token == "tok"
-        assert cfg.eps_meters == 40
-        assert cfg.min_surface_ha == 0.3
-        assert cfg.alpha == 0.07
     assert called == [1]
     status = client.get("/analysis_status")
     assert status.json == {
@@ -181,28 +155,17 @@ def test_admin_accepts_decimal_comma(make_app, monkeypatch):
     app = make_app()
     client = app.test_client()
     login(client)
-    devices = [{"id": 1, "name": "eq"}]
-    monkeypatch.setattr(zone, "fetch_devices", lambda: devices)
-    token = get_csrf(client, "/admin")
+    monkeypatch.setattr(zone, "fetch_devices", lambda: [])
+    token = get_csrf(client, "/admin/analysis")
     resp = client.post(
-        "/admin",
-        data={
-            "base_url": "http://new.com",
-            "token_global": "tok",
-            "follow_t1": "1",
-            "type_t1": "tractor",
-            "include_t1": "1",
-            "eps_meters": "40,0",
-            "analysis_hour": "3",
-            "csrf_token": token,
-        },
+        "/admin/analysis",
+        data={"eps_meters": "40,0", "analysis_hour": "3", "csrf_token": token},
     )
     assert resp.status_code == 200
     with app.app_context():
         cfg = Config.query.first()
-        assert cfg.traccar_url == "http://new.com"
-        assert cfg.traccar_token == "tok"
         assert cfg.eps_meters == 40.0
+        assert cfg.analysis_hour == 3
 
 
 def test_reanalyze_accepts_decimal_comma(make_app, monkeypatch):
@@ -231,15 +194,10 @@ def test_reanalyze_accepts_decimal_comma(make_app, monkeypatch):
 
     monkeypatch.setattr(zone, "process_equipment", fake_process)
 
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post(
         "/reanalyze_all",
         data={
-            "base_url": "http://new.com",
-            "token_global": "tok",
-            "follow_t1": "1",
-            "type_t1": "tractor",
-            "include_t1": "1",
             "eps_meters": "40,0",
             "min_surface": "0,3",
             "alpha_shape": "0,07",
@@ -253,4 +211,5 @@ def test_reanalyze_accepts_decimal_comma(make_app, monkeypatch):
         assert cfg.eps_meters == 40.0
         assert cfg.min_surface_ha == 0.3
         assert cfg.alpha == 0.07
+        assert cfg.analysis_hour == 4
     assert called == [1]

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -12,7 +12,7 @@ def test_post_without_csrf_returns_400(make_app):
     app = make_app()
     client = app.test_client()
     login(client)
-    resp = client.post("/admin", data={"base_url": "http://new.com"})
+    resp = client.post("/admin/equipment", data={"base_url": "http://new.com"})
     assert resp.status_code == 400
 
 

--- a/tests/test_index_summary.py
+++ b/tests/test_index_summary.py
@@ -123,7 +123,7 @@ def test_reanalysis_updates_index_table(make_app, monkeypatch):
     monkeypatch.setattr(threading, "Thread", InstantThread)
 
     monkeypatch.setattr(zone, "fetch_devices", lambda: [])
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post("/reanalyze_all", data={"csrf_token": token})
     assert resp.status_code in (200, 302)
 

--- a/tests/test_osmand_ingest.py
+++ b/tests/test_osmand_ingest.py
@@ -179,7 +179,7 @@ def test_admin_add_osmand_device(make_app):
     client = app.test_client()
     # login
     login(client)
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post(
         "/admin/add_osmand",
         data={

--- a/tests/test_toggle_analysis.py
+++ b/tests/test_toggle_analysis.py
@@ -15,9 +15,9 @@ def test_toggle_analysis(make_app, monkeypatch):
         form_id = f"t{eq.id_traccar}"
         assert eq.include_in_analysis is True
 
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     client.post(
-        "/admin",
+        "/admin/equipment",
         data={
             f"type_{form_id}": "tractor",
             f"include_{form_id}": "0",
@@ -29,9 +29,9 @@ def test_toggle_analysis(make_app, monkeypatch):
     with app.app_context():
         assert db.session.get(Equipment, eq_id).include_in_analysis is False
 
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     client.post(
-        "/admin",
+        "/admin/equipment",
         data={
             f"include_{form_id}": "1",
             f"type_{form_id}": "car",

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -36,7 +36,7 @@ def test_non_admin_cannot_access_admin_page(make_app):
         db.session.commit()
     client = app.test_client()
     login(client, "reader", "pwd")
-    resp = client.get("/admin")
+    resp = client.get("/admin/equipment")
     assert resp.status_code == 302
 
 
@@ -132,7 +132,7 @@ def test_admin_can_trigger_reanalyze(make_app, monkeypatch):
 
     monkeypatch.setattr(threading, "Thread", InstantThread)
 
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post("/reanalyze_all", data={"csrf_token": token})
     assert resp.status_code == 302
     assert called == [1]
@@ -169,7 +169,7 @@ def test_admin_can_reanalyze_via_post(make_app, monkeypatch):
     monkeypatch.setattr(threading, "Thread", InstantThread)
 
     monkeypatch.setattr(zone, "fetch_devices", lambda: [])
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post("/reanalyze_all", data={"csrf_token": token})
     assert resp.status_code == 302
     assert called == [1]
@@ -225,7 +225,7 @@ def test_analysis_status_reports_equipment(make_app, monkeypatch):
     monkeypatch.setattr(zone, "process_equipment", fake_process)
 
     monkeypatch.setattr(zone, "fetch_devices", lambda: [])
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/equipment")
     resp = client.post("/reanalyze_all", data={"csrf_token": token})
     assert resp.status_code == 302
 

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -32,16 +32,12 @@ def test_admin_invalid_url_validation(make_app, monkeypatch):
     client = app.test_client()
     login(client)
     monkeypatch.setattr(zone, "fetch_devices", lambda: [])
-    token = get_csrf(client, "/admin")
+    token = get_csrf(client, "/admin/traccar")
     resp = client.post(
-        "/admin",
+        "/admin/traccar",
         data={
             "base_url": "not a url",
             "token_global": "tok",
-            "eps_meters": "10",
-            "min_surface": "0.1",
-            "alpha_shape": "0.5",
-            "analysis_hour": "2",
             "csrf_token": token,
         },
     )


### PR DESCRIPTION
## Summary
- break monolithic admin page into dedicated sections for equipment, analysis and Traccar settings
- consolidate admin links under a single navbar dropdown
- adjust tests for new admin routes

## Testing
- `flake8 .` *(fails: E501 line too long, E402 import order)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_689d50e438608322a73d63a32962a8d3