### PR TITLE
Handle lowercase dev branch in update page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,11 +60,11 @@ Les agents peuvent être exécutés automatiquement ou manuellement :
 | `analyse_initiale`         | au démarrage     | automatique |
 | `rapport_par_tracteur`     | futur            | script manuel  |
 | `verificateur_inactivite`  | futur            | planifié       |
-| `release_gh_action`        | à chaque merge de `Dev` vers `main` | GitHub Actions |
+| `release_gh_action`        | à chaque merge de `dev` vers `main` | GitHub Actions |
 | `admin_update`             | sur demande      | interface admin (branche choisie) |
 
 Les versions suivent le format `année.mois.version`.
-Le développement se fait sur la branche `Dev` avant fusion dans `main`.
+Le développement se fait sur la branche `dev` avant fusion dans `main`.
 
 ---
 

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -16,7 +16,7 @@ def test_admin_update_get(make_app, monkeypatch):
         app_module, "get_latest_version", lambda branch: "2025.08.1"
     )
     monkeypatch.setattr(
-        app_module, "get_available_branches", lambda: ["main", "Dev"]
+        app_module, "get_available_branches", lambda: ["main", "dev"]
     )
     resp = client.get("/admin/update")
     assert resp.status_code == 200
@@ -41,7 +41,7 @@ def test_admin_update_post(make_app, monkeypatch):
 
     monkeypatch.setattr(app_module, "get_latest_version", fake_latest)
     monkeypatch.setattr(
-        app_module, "get_available_branches", lambda: ["main", "Dev"]
+        app_module, "get_available_branches", lambda: ["main", "dev"]
     )
     called = {}
 


### PR DESCRIPTION
## Summary
- resolve branch case mismatch by defaulting to lowercase `dev`
- fall back to commit hash for current version and compare branches case-insensitively
- adjust tests and docs for lowercase branch

## Testing
- `flake8 .` *(fails: E501 line too long, etc.)*
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68abd083e8f083229d32a8659857d077