### PR TITLE
Use repository remote for update API URL

### DIFF
--- a/tests/test_update_utils.py
+++ b/tests/test_update_utils.py
@@ -1,0 +1,31 @@
+"""Tests for update utility functions."""
+
+import subprocess
+
+from update import (
+    _get_repo_releases_api_url,
+    DEFAULT_REPO_RELEASES_API_URL,
+)
+
+
+def test_get_repo_releases_api_url_https(monkeypatch):
+    """Origin URL via HTTPS should map to the correct API endpoint."""
+
+    def fake_check_output(cmd, stderr=None, text=None):
+        return "https://github.com/foo/bar.git"
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+    assert (
+        _get_repo_releases_api_url()
+        == "https://api.github.com/repos/foo/bar/releases"
+    )
+
+
+def test_get_repo_releases_api_url_fallback(monkeypatch):
+    """Missing or invalid remote should fall back to the default URL."""
+
+    def fake_check_output(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0])
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+    assert _get_repo_releases_api_url() == DEFAULT_REPO_RELEASES_API_URL


### PR DESCRIPTION
## Summary
- build GitHub releases API URL from configured git remote
- add tests for dynamic releases URL resolution

## Testing
- `flake8 .` *(fails: E501 etc. in existing files)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68abd21ede1c8322af82ca7f034a5ebb