### PR TITLE
Add version fallback for update page

### DIFF
--- a/__version__.py
+++ b/__version__.py
@@ -1,0 +1,3 @@
+"""Application version information."""
+
+__version__ = "0.0.0"

--- a/tests/test_version_fallback.py
+++ b/tests/test_version_fallback.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+
+import update
+from __version__ import __version__ as file_version
+
+
+def test_get_current_version_uses_version_file(monkeypatch):
+    """Use ``__version__`` when git metadata is unavailable."""
+
+    def raise_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "cmd")
+
+    monkeypatch.setattr(update.subprocess, "check_output", raise_error)
+    assert update.get_current_version() == file_version

--- a/update.py
+++ b/update.py
@@ -62,7 +62,14 @@ def _parse_version(version: str) -> Tuple[int, int, int]:
 
 
 def get_current_version() -> str:
-    """Return the latest Git tag or commit hash for the repository."""
+    """Return the latest Git tag or commit hash for the repository.
+
+    If the repository metadata cannot be retrieved (for example when running
+    from a release archive without the ``.git`` directory), the function falls
+    back to reading the ``__version__`` module.  When that file is missing as
+    well, ``"0.0.0"`` is returned.
+    """
+
     try:
         return (
             subprocess.check_output(
@@ -83,7 +90,12 @@ def get_current_version() -> str:
                 .strip()
             )
         except (subprocess.CalledProcessError, OSError):
-            return "0.0.0"
+            try:
+                from __version__ import __version__
+
+                return __version__
+            except Exception:
+                return "0.0.0"
 
 
 def get_latest_version(branch: str = "main") -> str:


### PR DESCRIPTION
## Summary
- add `__version__` module to store application version
- update `get_current_version` to use `__version__` when Git metadata is missing
- test fallback to version file

## Testing
- `flake8 .` *(fails: style issues in existing files)*
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68abd4512c748322ba40f3ed762a88a9