### PR TITLE
Add beta release workflow and version-based updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,23 +22,28 @@ jobs:
         run: |
           git fetch --tags --force --prune
 
-      - name: "Calculate version (CALVER: YYYY.MM.PATCH)"
+      - name: "Calculate version (CALVER with beta)"
         id: calver
         shell: bash
         run: |
           YEAR=$(date +%Y)
-          MONTH=$(date +%m)
+          MONTH=$(date +%m | sed 's/^0//')
           BASE="$YEAR.$MONTH"
 
-          # Récupère le dernier patch de ce mois/année (robuste, tri numérique)
-          LAST=$(git tag --list "${BASE}.*" | sed -E "s#^${BASE}\.##" | sort -n | tail -n 1)
-          if [ -z "$LAST" ]; then
-            PATCH=0
+          LAST_STABLE=$(git tag --list "${BASE}.*" | grep -E "^${BASE}\\.[0-9]+$" | sed -E "s#^${BASE}\.##" | sort -n | tail -n 1)
+          if [ -z "$LAST_STABLE" ]; then
+            LAST_STABLE=0
+          fi
+          NEXT=$((LAST_STABLE + 1))
+
+          if [ "$GITHUB_REF" = "refs/heads/dev" ]; then
+            BETA_COUNT=$(git tag --list "${BASE}.${NEXT}b*" | wc -l)
+            BETA=$((BETA_COUNT + 1))
+            VERSION="${BASE}.${NEXT}b${BETA}"
           else
-            PATCH=$((LAST + 1))
+            VERSION="${BASE}.${NEXT}"
           fi
 
-          VERSION="${BASE}.${PATCH}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Update __version__.py
@@ -62,9 +67,7 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.calver.outputs.version }}" || echo "No changes to commit"
           git push || echo "Nothing to push"
 
-      # On ne crée le tag et la release QUE sur main
       - name: Create tag
-        if: github.ref == 'refs/heads/main'
         run: |
           if git rev-parse -q --verify "refs/tags/${{ steps.calver.outputs.version }}" >/dev/null; then
             echo "Tag already exists, skipping tag creation."
@@ -74,12 +77,11 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.calver.outputs.version }}
           name: ${{ steps.calver.outputs.version }}
           draft: false
-          prerelease: false
+          prerelease: ${{ github.ref == 'refs/heads/dev' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Les agents peuvent être exécutés automatiquement ou manuellement :
 | `rapport_par_tracteur`     | futur            | script manuel  |
 | `verificateur_inactivite`  | futur            | planifié       |
 | `release_gh_action`        | à chaque merge de `dev` vers `main` | GitHub Actions |
-| `admin_update`             | sur demande      | interface admin (branche choisie) |
+| `admin_update`             | sur demande      | interface admin (version choisie) |
 
 Les versions suivent le format `année.mois.version`.
 Le développement se fait sur la branche `dev` avant fusion dans `main`.

--- a/app.py
+++ b/app.py
@@ -55,9 +55,9 @@ import zone
 from update import (
     get_current_version,
     get_latest_version,
+    get_available_versions,
     is_update_available,
     perform_update,
-    get_available_branches,
 )
 
 from datetime import datetime, date, timedelta, timezone
@@ -793,25 +793,24 @@ def create_app(
         """Vérifier et appliquer les mises à jour de l'application."""
         if not current_user.is_admin:
             return redirect(url_for('index'))
-        branches = get_available_branches()
+        versions = get_available_versions()
         form = UpdateForm()
-        form.branch.choices = [(b, b) for b in branches]
-        if not form.branch.data:
-            form.branch.data = branches[0]
-        branch = form.branch.data
+        form.version.choices = [(v, v) for v in versions]
+        if not form.version.data and versions:
+            form.version.data = versions[0]
+        version = form.version.data
         current_version = get_current_version()
-        latest_version = get_latest_version(branch)
+        latest_version = get_latest_version()
         message = None
         error = None
 
         if request.method == 'POST' and form.validate_on_submit():
-            branch = form.branch.data
-            latest_version = get_latest_version(branch)
-            if latest_version and is_update_available(current_version, latest_version):
+            version = form.version.data
+            if is_update_available(current_version, version):
                 try:
-                    perform_update(branch)
+                    perform_update(version)
                     current_version = get_current_version()
-                    latest_version = get_latest_version(branch)
+                    latest_version = get_latest_version()
                     message = (
                         f"Mise à jour vers la version {current_version} effectuée."
                     )

--- a/forms.py
+++ b/forms.py
@@ -134,6 +134,6 @@ class SimAssociationForm(FlaskForm):
 
 
 class UpdateForm(FlaskForm):
-    """Formulaire permettant de choisir la branche à mettre à jour."""
+    """Formulaire permettant de choisir la version à mettre à jour."""
 
-    branch = SelectField("Branche", choices=[], validators=[DataRequired()])
+    version = SelectField("Version", choices=[], validators=[DataRequired()])

--- a/templates/admin_update.html
+++ b/templates/admin_update.html
@@ -58,10 +58,10 @@
     <form method="post">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
-        {{ form.branch.label(class="form-label") }}
-        {{ form.branch(class="form-select") }}
+        {{ form.version.label(class="form-label") }}
+        {{ form.version(class="form-select") }}
       </div>
-      <button type="submit" class="btn btn-primary" {% if not latest_version or current_version == latest_version %}disabled{% endif %}>
+      <button type="submit" class="btn btn-primary" {% if form.version.data == current_version %}disabled{% endif %}>
         Mettre à jour
       </button>
     </form>

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -12,11 +12,9 @@ def test_admin_update_get(make_app, monkeypatch):
     monkeypatch.setattr(
         app_module, "get_current_version", lambda: "2025.08.0"
     )
+    monkeypatch.setattr(app_module, "get_latest_version", lambda: "2025.08.1")
     monkeypatch.setattr(
-        app_module, "get_latest_version", lambda branch: "2025.08.1"
-    )
-    monkeypatch.setattr(
-        app_module, "get_available_branches", lambda: ["main", "dev"]
+        app_module, "get_available_versions", lambda: ["2025.08.1", "2025.08.0"]
     )
     resp = client.get("/admin/update")
     assert resp.status_code == 200
@@ -33,29 +31,22 @@ def test_admin_update_post(make_app, monkeypatch):
     monkeypatch.setattr(
         app_module, "get_current_version", lambda: next(versions)
     )
-    seen = {}
-
-    def fake_latest(branch: str) -> str:
-        seen["branch_latest"] = branch
-        return "2025.08.1"
-
-    monkeypatch.setattr(app_module, "get_latest_version", fake_latest)
+    monkeypatch.setattr(app_module, "get_latest_version", lambda: "2025.08.1")
     monkeypatch.setattr(
-        app_module, "get_available_branches", lambda: ["main", "dev"]
+        app_module, "get_available_versions", lambda: ["2025.08.1", "2025.08.0"]
     )
     called = {}
 
-    def fake_update(branch: str) -> None:
-        called["branch"] = branch
+    def fake_update(version: str) -> None:
+        called["version"] = version
 
     monkeypatch.setattr(app_module, "perform_update", fake_update)
     token = get_csrf(client, "/admin/update")
     resp = client.post(
         "/admin/update",
-        data={"csrf_token": token, "branch": "main"},
+        data={"csrf_token": token, "version": "2025.08.1"},
         follow_redirects=False,
     )
     assert resp.status_code == 200
-    assert called.get("branch") == "main"
-    assert seen.get("branch_latest") == "main"
+    assert called.get("version") == "2025.08.1"
     assert "2025.08.1" in resp.get_data(as_text=True)

--- a/tests/test_update_utils.py
+++ b/tests/test_update_utils.py
@@ -5,6 +5,7 @@ import subprocess
 from update import (
     _get_repo_releases_api_url,
     DEFAULT_REPO_RELEASES_API_URL,
+    is_update_available,
 )
 
 
@@ -29,3 +30,11 @@ def test_get_repo_releases_api_url_fallback(monkeypatch):
 
     monkeypatch.setattr(subprocess, "check_output", fake_check_output)
     assert _get_repo_releases_api_url() == DEFAULT_REPO_RELEASES_API_URL
+
+
+def test_is_update_available_beta():
+    """Beta versions should compare lower than their stable counterparts."""
+
+    assert is_update_available("2025.8.1b1", "2025.8.1")
+    assert is_update_available("2025.8.1b1", "2025.8.1b2")
+    assert not is_update_available("2025.8.1", "2025.8.1b1")


### PR DESCRIPTION
## Summary
- enable CALVER beta tags on `dev` and stable releases on `main`
- allow admins to pick a specific version for updates
- adjust tests for version-based update flow

## Testing
- `flake8 .` *(fails: E501 line too long and others)*
- `python -m mypy update.py` and `python -m mypy .` *(success)*
- `pytest --cov=.` *(interrupted: 70 passed, 3 xfailed, 3 xpassed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac37cb86088322aa21792f21953123