### PR TITLE
Add beta tester update mode and release notes link

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  web:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+      - ./instance:/app/instance
+    ports:
+      - '5000:5000'
+    environment:
+      - FLASK_APP=wsgi.py
+      - FLASK_RUN_HOST=0.0.0.0
+    command: >
+      sh -c "apt-get update && apt-get install -y git && pip install -r requirements.txt && flask run --host=0.0.0.0"

--- a/forms.py
+++ b/forms.py
@@ -8,6 +8,7 @@ from wtforms import (
     FloatField,
     HiddenField,
     SelectField,
+    BooleanField,
 )
 from wtforms.validators import (
     DataRequired,
@@ -137,3 +138,4 @@ class UpdateForm(FlaskForm):
     """Formulaire permettant de choisir la version à mettre à jour."""
 
     version = SelectField("Version", choices=[], validators=[DataRequired()])
+    include_prerelease = BooleanField("Mode bêta testeur")

--- a/models.py
+++ b/models.py
@@ -28,6 +28,7 @@ class Config(db.Model):  # type: ignore[name-defined]
     min_surface_ha = db.Column(db.Float, default=0.1)
     alpha = db.Column(db.Float, default=0.02)
     analysis_hour = db.Column(db.Integer, default=2)
+    beta_updates = db.Column(db.Boolean, default=False)
 
 
 class Equipment(db.Model):  # type: ignore[name-defined]

--- a/templates/admin_analysis.html
+++ b/templates/admin_analysis.html
@@ -110,5 +110,6 @@
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     [...tooltipTriggerList].forEach(el => new bootstrap.Tooltip(el));
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_equipment.html
+++ b/templates/admin_equipment.html
@@ -277,5 +277,6 @@
       });
     }
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_providers.html
+++ b/templates/admin_providers.html
@@ -70,5 +70,6 @@
     </form>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_traccar.html
+++ b/templates/admin_traccar.html
@@ -81,5 +81,6 @@
       a.addEventListener('touchend', function () { window.location.href = this.href; });
     });
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_update.html
+++ b/templates/admin_update.html
@@ -54,12 +54,16 @@
       {% if message %}{{ message }}{% elif error %}{{ error }}{% endif %}
     </div>
     <p>Version actuelle : {{ current_version }}</p>
-    <p>Dernière version : {{ latest_version or 'inconnue' }}</p>
+    <p>Dernière version : {{ latest_version or 'inconnue' }}{% if release_notes_url %} - <a href="{{ release_notes_url }}" target="_blank">Notes de version</a>{% endif %}</p>
     <form method="post">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         {{ form.version.label(class="form-label") }}
         {{ form.version(class="form-select") }}
+      </div>
+      <div class="form-check mb-3">
+        {{ form.include_prerelease(class="form-check-input") }}
+        {{ form.include_prerelease.label(class="form-check-label") }}
       </div>
       <button type="submit" class="btn btn-primary" {% if form.version.data == current_version %}disabled{% endif %}>
         Mettre à jour
@@ -68,5 +72,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -885,5 +885,6 @@
     });
   </script>
   <script src="{{ url_for('static', filename='js/equipment-sheet.js') }}"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -397,5 +397,6 @@
       });
     });
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -41,5 +41,7 @@
       </form>
     </div>
   </section>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/setup_step1.html
+++ b/templates/setup_step1.html
@@ -27,5 +27,7 @@
       <button type="submit" class="btn btn-primary">Créer l'administrateur</button>
     </form>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/update_modal.html
+++ b/templates/update_modal.html
@@ -1,0 +1,27 @@
+{% if update_info.update_available %}
+<div class="modal fade" id="updateModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Nouvelle version disponible</h5>
+      </div>
+      <div class="modal-body">
+        Version {{ update_info.latest_version }} disponible. 
+        <a href="{{ update_info.release_notes_url }}" target="_blank">Notes de version</a>
+      </div>
+      <div class="modal-footer">
+        <a class="btn btn-primary" href="{{ url_for('admin_update') }}">Mettre à jour</a>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var modal = document.getElementById('updateModal');
+    if (modal) {
+      var m = new bootstrap.Modal(modal);
+      m.show();
+    }
+  });
+</script>
+{% endif %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -133,5 +133,6 @@
       a.addEventListener('touchend', function () { window.location.href = this.href; });
     });
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ from models import db, User, Config, Equipment
 def make_app():
     original = os.environ.get("SKIP_INITIAL_ANALYSIS")
     os.environ["SKIP_INITIAL_ANALYSIS"] = "1"
+    orig_update = os.environ.get("CHECK_UPDATES")
+    os.environ["CHECK_UPDATES"] = "0"
 
     def _make_app():
         app = create_app(start_scheduler=False, run_initial_analysis=False)
@@ -48,6 +50,10 @@ def make_app():
             os.environ.pop("SKIP_INITIAL_ANALYSIS", None)
         else:
             os.environ["SKIP_INITIAL_ANALYSIS"] = original
+        if orig_update is None:
+            os.environ.pop("CHECK_UPDATES", None)
+        else:
+            os.environ["CHECK_UPDATES"] = orig_update
 
 
 

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -12,15 +12,23 @@ def test_admin_update_get(make_app, monkeypatch):
     monkeypatch.setattr(
         app_module, "get_current_version", lambda: "2025.08.0"
     )
-    monkeypatch.setattr(app_module, "get_latest_version", lambda: "2025.08.1")
     monkeypatch.setattr(
-        app_module, "get_available_versions", lambda: ["2025.08.1", "2025.08.0"]
+        app_module, "get_latest_version", lambda include_prerelease=False: "2025.08.1"
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_available_versions",
+        lambda include_prerelease=False: ["2025.08.1", "2025.08.0"],
+    )
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
     )
     resp = client.get("/admin/update")
     assert resp.status_code == 200
     data = resp.get_data(as_text=True)
     assert "2025.08.0" in data
     assert "2025.08.1" in data
+    assert "https://example.com/2025.08.1" in data
 
 
 def test_admin_update_post(make_app, monkeypatch):
@@ -31,9 +39,16 @@ def test_admin_update_post(make_app, monkeypatch):
     monkeypatch.setattr(
         app_module, "get_current_version", lambda: next(versions)
     )
-    monkeypatch.setattr(app_module, "get_latest_version", lambda: "2025.08.1")
     monkeypatch.setattr(
-        app_module, "get_available_versions", lambda: ["2025.08.1", "2025.08.0"]
+        app_module, "get_latest_version", lambda include_prerelease=False: "2025.08.1"
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_available_versions",
+        lambda include_prerelease=False: ["2025.08.1", "2025.08.0"],
+    )
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
     )
     called = {}
 
@@ -50,3 +65,51 @@ def test_admin_update_post(make_app, monkeypatch):
     assert resp.status_code == 200
     assert called.get("version") == "2025.08.1"
     assert "2025.08.1" in resp.get_data(as_text=True)
+
+
+def test_beta_mode_shows_prerelease(make_app, monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    monkeypatch.setattr(app_module, "get_current_version", lambda: "2025.08.0")
+
+    def fake_latest(include_prerelease=False):
+        return "2025.08.1b1" if include_prerelease else "2025.08.0"
+
+    def fake_versions(include_prerelease=False):
+        return ["2025.08.1b1", "2025.08.0"] if include_prerelease else ["2025.08.0"]
+
+    monkeypatch.setattr(app_module, "get_latest_version", fake_latest)
+    monkeypatch.setattr(app_module, "get_available_versions", fake_versions)
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
+    )
+    resp = client.get("/admin/update")
+    assert "2025.08.1b1" not in resp.get_data(as_text=True)
+
+    token = get_csrf(client, "/admin/update")
+    resp = client.post(
+        "/admin/update",
+        data={"csrf_token": token, "version": "2025.08.0", "include_prerelease": "y"},
+    )
+    assert resp.status_code == 200
+    resp = client.get("/admin/update")
+    assert "2025.08.1b1" in resp.get_data(as_text=True)
+
+
+def test_update_modal_shown(make_app, monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    monkeypatch.setenv("CHECK_UPDATES", "1")
+    monkeypatch.setattr(app_module, "get_current_version", lambda: "2025.08.0")
+    monkeypatch.setattr(
+        app_module, "get_latest_version", lambda include_prerelease=False: "2025.08.1"
+    )
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
+    )
+    resp = client.get("/")
+    data = resp.get_data(as_text=True)
+    assert "updateModal" in data
+    assert "2025.08.1" in data


### PR DESCRIPTION
## Summary
- add beta tester mode to surface prerelease versions
- show release notes link and persistent update modal
- include docker-compose configuration with git to support updates inside containers

## Testing
- `flake8 .` *(fails: line too long across project)*
- `mypy .`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68ac4157a9888322b06def5dd4ff0e81