### PR TITLE
Add beta tester update mode and release notes link

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ from update import (
     get_current_version,
     get_latest_version,
     get_available_versions,
+    get_release_notes_url,
     is_update_available,
     perform_update,
 )
@@ -241,6 +242,13 @@ def create_app(
                         text(
                             "ALTER TABLE config ADD COLUMN analysis_hour "
                             "INTEGER DEFAULT 2"
+                        )
+                    )
+                if "beta_updates" not in config_cols:
+                    conn.execute(
+                        text(
+                            "ALTER TABLE config ADD COLUMN beta_updates "
+                            "BOOLEAN DEFAULT 0"
                         )
                     )
         if "daily_zone" in tables:
@@ -793,24 +801,41 @@ def create_app(
         """Vérifier et appliquer les mises à jour de l'application."""
         if not current_user.is_admin:
             return redirect(url_for('index'))
-        versions = get_available_versions()
+        cfg = Config.query.first()
+        include_pre = bool(cfg.beta_updates) if cfg else False
+        versions = get_available_versions(include_prerelease=include_pre)
         form = UpdateForm()
         form.version.choices = [(v, v) for v in versions]
+        if cfg and request.method != 'POST':
+            form.include_prerelease.data = cfg.beta_updates
         if not form.version.data and versions:
             form.version.data = versions[0]
         version = form.version.data
         current_version = get_current_version()
-        latest_version = get_latest_version()
+        latest_version = get_latest_version(include_prerelease=include_pre)
+        release_notes_url = (
+            get_release_notes_url(latest_version) if latest_version else None
+        )
         message = None
         error = None
 
         if request.method == 'POST' and form.validate_on_submit():
+            if cfg:
+                cfg.beta_updates = form.include_prerelease.data
+                db.session.commit()
             version = form.version.data
             if is_update_available(current_version, version):
                 try:
                     perform_update(version)
                     current_version = get_current_version()
-                    latest_version = get_latest_version()
+                    latest_version = get_latest_version(
+                        include_prerelease=form.include_prerelease.data
+                    )
+                    release_notes_url = (
+                        get_release_notes_url(latest_version)
+                        if latest_version
+                        else None
+                    )
                     message = (
                         f"Mise à jour vers la version {current_version} effectuée."
                     )
@@ -823,6 +848,7 @@ def create_app(
             'admin_update.html',
             current_version=current_version,
             latest_version=latest_version,
+            release_notes_url=release_notes_url,
             message=message,
             error=error,
             form=form,
@@ -2194,7 +2220,7 @@ def create_app(
         # Prepare CSV
         output = io.StringIO()
         writer = csv.writer(output)
-        writer.writerow(["latitude", "longitude", "timestamp", "battery_level"]) 
+        writer.writerow(["latitude", "longitude", "timestamp", "battery_level"])
 
         if getattr(eq, 'id_traccar', None):
             # Fetch from Traccar directly to include attributes like battery.
@@ -2228,7 +2254,7 @@ def create_app(
                         batt = None
                 if lat is None or lon is None or ts is None:
                     continue
-                writer.writerow([lat, lon, ts.isoformat(), batt if batt is not None else ""])            
+                writer.writerow([lat, lon, ts.isoformat(), batt if batt is not None else ""])
         else:
             # Export from local DB positions (OsmAnd or stored).
             query = Position.query.filter_by(equipment_id=eq.id)
@@ -2302,6 +2328,24 @@ def create_app(
 
     if run_initial_analysis and not os.environ.get("SKIP_INITIAL_ANALYSIS"):
         initial_analysis()
+
+    @app.context_processor
+    def inject_update_info():
+        if os.environ.get("CHECK_UPDATES", "1") == "0":
+            return {"update_info": {"update_available": False}}
+        cfg = Config.query.first()
+        include_pre = bool(cfg.beta_updates) if cfg else False
+        current = get_current_version()
+        latest = get_latest_version(include_prerelease=include_pre)
+        if latest and is_update_available(current, latest):
+            return {
+                "update_info": {
+                    "update_available": True,
+                    "latest_version": latest,
+                    "release_notes_url": get_release_notes_url(latest),
+                }
+            }
+        return {"update_info": {"update_available": False}}
 
     @app.after_request
     def set_security_headers(resp):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  web:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+      - ./instance:/app/instance
+    ports:
+      - '8000:8000'
+    environment:
+      - FLASK_APP=wsgi.py
+      - FLASK_RUN_HOST=0.0.0.0
+      - FLASK_RUN_PORT=8000
+    command: >
+      sh -c "apt-get update && apt-get install -y git && pip install -r requirements.txt && flask run --host=0.0.0.0 --port=8000"

--- a/forms.py
+++ b/forms.py
@@ -8,6 +8,7 @@ from wtforms import (
     FloatField,
     HiddenField,
     SelectField,
+    BooleanField,
 )
 from wtforms.validators import (
     DataRequired,
@@ -137,3 +138,4 @@ class UpdateForm(FlaskForm):
     """Formulaire permettant de choisir la version à mettre à jour."""
 
     version = SelectField("Version", choices=[], validators=[DataRequired()])
+    include_prerelease = BooleanField("Mode bêta testeur")

--- a/models.py
+++ b/models.py
@@ -28,6 +28,7 @@ class Config(db.Model):  # type: ignore[name-defined]
     min_surface_ha = db.Column(db.Float, default=0.1)
     alpha = db.Column(db.Float, default=0.02)
     analysis_hour = db.Column(db.Integer, default=2)
+    beta_updates = db.Column(db.Boolean, default=False)
 
 
 class Equipment(db.Model):  # type: ignore[name-defined]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 200

--- a/templates/admin_analysis.html
+++ b/templates/admin_analysis.html
@@ -110,5 +110,6 @@
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     [...tooltipTriggerList].forEach(el => new bootstrap.Tooltip(el));
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_equipment.html
+++ b/templates/admin_equipment.html
@@ -277,5 +277,6 @@
       });
     }
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_providers.html
+++ b/templates/admin_providers.html
@@ -70,5 +70,6 @@
     </form>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_traccar.html
+++ b/templates/admin_traccar.html
@@ -81,5 +81,6 @@
       a.addEventListener('touchend', function () { window.location.href = this.href; });
     });
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/admin_update.html
+++ b/templates/admin_update.html
@@ -54,12 +54,16 @@
       {% if message %}{{ message }}{% elif error %}{{ error }}{% endif %}
     </div>
     <p>Version actuelle : {{ current_version }}</p>
-    <p>Dernière version : {{ latest_version or 'inconnue' }}</p>
+    <p>Dernière version : {{ latest_version or 'inconnue' }}{% if release_notes_url %} - <a href="{{ release_notes_url }}" target="_blank">Notes de version</a>{% endif %}</p>
     <form method="post">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         {{ form.version.label(class="form-label") }}
         {{ form.version(class="form-select") }}
+      </div>
+      <div class="form-check mb-3">
+        {{ form.include_prerelease(class="form-check-input") }}
+        {{ form.include_prerelease.label(class="form-check-label") }}
       </div>
       <button type="submit" class="btn btn-primary" {% if form.version.data == current_version %}disabled{% endif %}>
         Mettre à jour
@@ -68,5 +72,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/equipment.html
+++ b/templates/equipment.html
@@ -885,5 +885,6 @@
     });
   </script>
   <script src="{{ url_for('static', filename='js/equipment-sheet.js') }}"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -397,5 +397,6 @@
       });
     });
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -41,5 +41,7 @@
       </form>
     </div>
   </section>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/setup_step1.html
+++ b/templates/setup_step1.html
@@ -27,5 +27,7 @@
       <button type="submit" class="btn btn-primary">Créer l'administrateur</button>
     </form>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/templates/update_modal.html
+++ b/templates/update_modal.html
@@ -1,0 +1,27 @@
+{% if update_info.update_available %}
+<div class="modal fade" id="updateModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Nouvelle version disponible</h5>
+      </div>
+      <div class="modal-body">
+        Version {{ update_info.latest_version }} disponible. 
+        <a href="{{ update_info.release_notes_url }}" target="_blank">Notes de version</a>
+      </div>
+      <div class="modal-footer">
+        <a class="btn btn-primary" href="{{ url_for('admin_update') }}">Mettre à jour</a>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var modal = document.getElementById('updateModal');
+    if (modal) {
+      var m = new bootstrap.Modal(modal);
+      m.show();
+    }
+  });
+</script>
+{% endif %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -133,5 +133,6 @@
       a.addEventListener('touchend', function () { window.location.href = this.href; });
     });
   </script>
+  {% include 'update_modal.html' %}
 </body>
 </html>

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -12,15 +12,23 @@ def test_admin_update_get(make_app, monkeypatch):
     monkeypatch.setattr(
         app_module, "get_current_version", lambda: "2025.08.0"
     )
-    monkeypatch.setattr(app_module, "get_latest_version", lambda: "2025.08.1")
     monkeypatch.setattr(
-        app_module, "get_available_versions", lambda: ["2025.08.1", "2025.08.0"]
+        app_module, "get_latest_version", lambda include_prerelease=False: "2025.08.1"
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_available_versions",
+        lambda include_prerelease=False: ["2025.08.1", "2025.08.0"],
+    )
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
     )
     resp = client.get("/admin/update")
     assert resp.status_code == 200
     data = resp.get_data(as_text=True)
     assert "2025.08.0" in data
     assert "2025.08.1" in data
+    assert "https://example.com/2025.08.1" in data
 
 
 def test_admin_update_post(make_app, monkeypatch):
@@ -31,9 +39,16 @@ def test_admin_update_post(make_app, monkeypatch):
     monkeypatch.setattr(
         app_module, "get_current_version", lambda: next(versions)
     )
-    monkeypatch.setattr(app_module, "get_latest_version", lambda: "2025.08.1")
     monkeypatch.setattr(
-        app_module, "get_available_versions", lambda: ["2025.08.1", "2025.08.0"]
+        app_module, "get_latest_version", lambda include_prerelease=False: "2025.08.1"
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_available_versions",
+        lambda include_prerelease=False: ["2025.08.1", "2025.08.0"],
+    )
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
     )
     called = {}
 
@@ -50,3 +65,51 @@ def test_admin_update_post(make_app, monkeypatch):
     assert resp.status_code == 200
     assert called.get("version") == "2025.08.1"
     assert "2025.08.1" in resp.get_data(as_text=True)
+
+
+def test_beta_mode_shows_prerelease(make_app, monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    monkeypatch.setattr(app_module, "get_current_version", lambda: "2025.08.0")
+
+    def fake_latest(include_prerelease=False):
+        return "2025.08.1b1" if include_prerelease else "2025.08.0"
+
+    def fake_versions(include_prerelease=False):
+        return ["2025.08.1b1", "2025.08.0"] if include_prerelease else ["2025.08.0"]
+
+    monkeypatch.setattr(app_module, "get_latest_version", fake_latest)
+    monkeypatch.setattr(app_module, "get_available_versions", fake_versions)
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
+    )
+    resp = client.get("/admin/update")
+    assert "2025.08.1b1" not in resp.get_data(as_text=True)
+
+    token = get_csrf(client, "/admin/update")
+    resp = client.post(
+        "/admin/update",
+        data={"csrf_token": token, "version": "2025.08.0", "include_prerelease": "y"},
+    )
+    assert resp.status_code == 200
+    resp = client.get("/admin/update")
+    assert "2025.08.1b1" in resp.get_data(as_text=True)
+
+
+def test_update_modal_shown(make_app, monkeypatch):
+    app = make_app()
+    client = app.test_client()
+    login(client)
+    monkeypatch.setenv("CHECK_UPDATES", "1")
+    monkeypatch.setattr(app_module, "get_current_version", lambda: "2025.08.0")
+    monkeypatch.setattr(
+        app_module, "get_latest_version", lambda include_prerelease=False: "2025.08.1"
+    )
+    monkeypatch.setattr(
+        app_module, "get_release_notes_url", lambda tag: f"https://example.com/{tag}"
+    )
+    resp = client.get("/")
+    data = resp.get_data(as_text=True)
+    assert "updateModal" in data
+    assert "2025.08.1" in data

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -9,7 +9,6 @@ if ROOT_DIR not in sys.path:
 os.environ.setdefault("TRACCAR_AUTH_TOKEN", "dummy")
 os.environ.setdefault("TRACCAR_BASE_URL", "http://example.com")
 
-import pytest  # noqa: E402
 from models import db, Equipment, Position  # noqa: E402
 from tests.utils import login  # noqa: E402
 import zone  # noqa: E402
@@ -35,7 +34,7 @@ def test_export_csv_osmand(make_app):
     assert resp.status_code == 200
     assert resp.mimetype.startswith("text/csv")
     text = resp.data.decode()
-    lines = [l for l in text.strip().splitlines() if l]
+    lines = [line for line in text.strip().splitlines() if line]
     # header + 2 rows
     assert lines[0].split(',') == ["latitude", "longitude", "timestamp", "battery_level"]
     assert len(lines) == 3
@@ -75,7 +74,7 @@ def test_export_csv_traccar(make_app, monkeypatch):
     resp = client.get(f"/equipment/{eqid}/export.csv?start={today}&end={today}")
     assert resp.status_code == 200
     text = resp.data.decode()
-    lines = [l for l in text.strip().splitlines() if l]
+    lines = [line for line in text.strip().splitlines() if line]
     assert lines[0].split(',') == ["latitude", "longitude", "timestamp", "battery_level"]
     # header + 2 rows
     assert len(lines) == 3

--- a/tests/test_sim_provider.py
+++ b/tests/test_sim_provider.py
@@ -114,6 +114,7 @@ def test_associate_sim_creates_record(make_app, monkeypatch):
         db.session.commit()
         pid = prov.id
         eqid = eq.id
+
     class Resp:
         status_code = 200
         text = "{}"

--- a/tests/test_upgrade_db.py
+++ b/tests/test_upgrade_db.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from sqlalchemy import inspect, text
+from sqlalchemy import inspect
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 if ROOT_DIR not in sys.path:

--- a/zone.py
+++ b/zone.py
@@ -15,14 +15,14 @@ from shapely.geometry import (
 from shapely.ops import transform as shp_transform
 import pyproj
 import alphashape
-# Ensure joblib uses a writable temp folder to avoid warnings in CI
-os.environ.setdefault("JOBLIB_TEMP_FOLDER", "/tmp")
 from sklearn.cluster import DBSCAN
 import folium
 from geopandas import GeoDataFrame
-
 from typing import Dict, List, Optional, Tuple
 from models import db, Equipment, Position, DailyZone, Config, Track
+
+# Ensure joblib uses a writable temp folder to avoid warnings in CI
+os.environ.setdefault("JOBLIB_TEMP_FOLDER", "/tmp")
 
 # Ignorer avertissements GEOS
 warnings.filterwarnings("ignore", "GEOS messages", UserWarning)


### PR DESCRIPTION
## Summary
- add beta tester mode to surface prerelease versions
- show release notes link and persistent update modal
- expose port 8000 in docker-compose for container use
- configure flake8 with relaxed line length and fix lint issues

## Testing
- `flake8 .`
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68ac4157a9888322b06def5dd4ff0e81