### PR TITLE
Expose service on port 8000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
       - .:/app
       - ./instance:/app/instance
     ports:
-      - '5000:5000'
+      - '8000:8000'
     environment:
       - FLASK_APP=wsgi.py
       - FLASK_RUN_HOST=0.0.0.0
+      - FLASK_RUN_PORT=8000
     command: >
-      sh -c "apt-get update && apt-get install -y git && pip install -r requirements.txt && flask run --host=0.0.0.0"
+      sh -c "apt-get update && apt-get install -y git && pip install -r requirements.txt && flask run --host=0.0.0.0 --port=8000"


### PR DESCRIPTION
## Summary
- expose Flask service on host port 8000 via docker compose

## Testing
- `flake8 .` *(fails: E501 line too long, and others)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68ac4e571290832296f9db8a7ad26eb9