### PR TITLE
build: use dedicated image and user in compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["flask", "run", "--host=0.0.0.0", "--port=8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: '3'
 services:
   web:
-    image: python:3.11-slim
+    build: .
+    user: "${UID}:${GID}"
     working_dir: /app
     volumes:
       - .:/app
       - ./instance:/app/instance
     ports:
-      - '8000:8000'
+      - "8000:8000"
     environment:
       - FLASK_APP=wsgi.py
       - FLASK_RUN_HOST=0.0.0.0
       - FLASK_RUN_PORT=8000
-    command: >
-      sh -c "apt-get update && apt-get install -y git && pip install -r requirements.txt && flask run --host=0.0.0.0 --port=8000"
+    command: flask run --host=0.0.0.0 --port=8000


### PR DESCRIPTION
## Summary
- build a custom image that preinstalls Git and dependencies
- run Docker Compose service as the host user and use the built image

## Testing
- `flake8 .` *(fails: E501 line too long and other pre-existing issues)*
- `mypy .`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68ac54b5096c8322a2deb628e819dd4e